### PR TITLE
Adding mysql service to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ mysql:
   username: root
   encoding: utf8
 
+services:
+  -mysql
+
 # Cache Composer and db export.
 # I removed caching of Drush since you have to clear Drush cache to get new Drupal versions.
 cache:


### PR DESCRIPTION
Should solve the `ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)` error on dev branch travis runs