### PR TITLE
Adding cu_saml module to pantheon_hosting dependencies list

### DIFF
--- a/modules/hosting/pantheon_hosting/pantheon_hosting.info
+++ b/modules/hosting/pantheon_hosting/pantheon_hosting.info
@@ -6,6 +6,7 @@ package = Hosting
 
 dependencies[] = pantheon_api
 dependencies[] = simplesamlphp_auth
+dependencies[] = cu_saml
 dependencies[] = dblog
 dependencies[] = redis
 dependencies[] = noreqnewpass


### PR DESCRIPTION
To test: `cu_saml` module should be enabled when `pantheon_hosting` is enabled