### PR TITLE
fixing notice of missing variable for intro region #325

### DIFF
--- a/themes/ucb/templates/page--title.tpl.php
+++ b/themes/ucb/templates/page--title.tpl.php
@@ -147,7 +147,7 @@
     <div class="page-content">
       <!-- INTRO -->
       <?php if (!empty($page['intro'])): ?>
-        <div id="intro-wide-wrapper" class="section intro-wide-wrapper <?php print $section['intro']['class']; ?>">
+        <div id="intro-wide-wrapper" class="section intro-wide-wrapper">
           <?php print render($page['intro']); ?>
         </div>
       <?php endif; ?>

--- a/themes/ucb/templates/page.tpl.php
+++ b/themes/ucb/templates/page.tpl.php
@@ -148,7 +148,7 @@
     <div class="page-content">
       <!-- INTRO -->
       <?php if (!empty($page['intro'])): ?>
-        <div id="intro-wide-wrapper" class="section intro-wide-wrapper <?php print $section['intro']['class']; ?>">
+        <div id="intro-wide-wrapper" class="section intro-wide-wrapper">
           <?php print render($page['intro']); ?>
         </div>
       <?php endif; ?>


### PR DESCRIPTION
Removed the output of the variable (that wasn't being set) so it's more consistent with how other wide regions work.

Wide regions are expected to have content fill the space, but text should never go all the way across and block sections should be used here to place content which provide their own background color.

The only blocks that should be used in these areas without an encompassing block section would be a hero unit, video hero unit, slider, or a text block with only an image.