### PR TITLE
adding new content grid examples to block page context #308

### DIFF
--- a/modules/custom/cu_test_content_admin_bundle/cu_test_content_blocks/cu_test_content_blocks.install
+++ b/modules/custom/cu_test_content_admin_bundle/cu_test_content_blocks/cu_test_content_blocks.install
@@ -249,6 +249,9 @@ function _cu_test_content_create_social_field_collection_item($bean, $type, $url
   return TRUE;
 }
 
+/**
+ * Create content grids on install - pass stype type by argument.
+ */
 function _cu_test_content_blocks_content_grid($style = NULL) {
   $temp_beans = variable_get('cu_test_content_beans', array());
 
@@ -339,7 +342,7 @@ function _cu_test_content_create_slider_field_collection_item($bean, $title, $or
   $fc_item = entity_create('field_collection_item', array('field_name' => 'field_slider_slide'));
   $fc_item->setHostEntity('bean', $bean);
   $text = _cu_test_content_grid_titles_dummy_text();
-  // Add button to slider text
+  // Add button to slider text.
   $text .= ' [button color="blue" url="node/1"]Learn More[/button]';
   $fc_item->field_slider_caption[LANGUAGE_NONE][$order]['value'] = $title;
   $fc_item->field_slider_teaser[LANGUAGE_NONE][$order]['value'] = $text;

--- a/modules/custom/cu_test_content_admin_bundle/cu_test_content_blocks/cu_test_content_blocks.install
+++ b/modules/custom/cu_test_content_admin_bundle/cu_test_content_blocks/cu_test_content_blocks.install
@@ -12,6 +12,8 @@ function cu_test_content_blocks_install() {
   _cu_test_content_blocks_hero();
   _cu_test_content_blocks_social();
   _cu_test_content_blocks_content_grid();
+  _cu_test_content_blocks_content_grid('teaser');
+  _cu_test_content_blocks_content_grid('cards');
   _cu_test_content_blocks_slider();
   _cu_test_content_blocks_article_slider();
   _cu_test_content_blocks_article_feature();
@@ -247,15 +249,20 @@ function _cu_test_content_create_social_field_collection_item($bean, $type, $url
   return TRUE;
 }
 
-function _cu_test_content_blocks_content_grid() {
+function _cu_test_content_blocks_content_grid($style = NULL) {
   $temp_beans = variable_get('cu_test_content_beans', array());
 
 
   $bean = bean_create(array('type' => 'feature_callout'));
   $bean->label = 'content_grid';
-  $bean->title = '';
   $bean->delta = 'content_grid';
+  $bean->title = '';
   $bean->field_callout_columns[LANGUAGE_NONE][0]['value'] = 3;
+  if ($style) {
+    $bean->field_callout_style[LANGUAGE_NONE][0]['value'] = $style;
+    $bean->label = 'content_grid_' . $style;
+    $bean->delta = 'content_grid_' . $style;
+  }
 
   $title_salt = _cu_test_content_grid_titles_dummy_text();
   $titles = explode('.', $title_salt);
@@ -277,7 +284,12 @@ function _cu_test_content_create_grid_field_collection_item($bean, $title, $imag
   $fc_item = entity_create('field_collection_item', array('field_name' => 'field_callouts'));
   $fc_item->setHostEntity('bean', $bean);
   $text = _cu_test_content_grid_dummy_text();
+  // Add buttons to content grid text.
+  $text .= '<p>[button color="blue" url="node/1"]This is a button[/button]</p>';
   $fc_item->field_callout_title[LANGUAGE_NONE][$order]['title'] = $title;
+  if ($order == 1) {
+    $fc_item->field_callout_title[LANGUAGE_NONE][$order]['url'] = 'node/1';
+  }
   $fc_item->field_callout_text[LANGUAGE_NONE][$order]['value'] = $text;
   $fc_item->field_callout_text[LANGUAGE_NONE][$order]['format'] = 'wysiwyg';
 
@@ -327,6 +339,8 @@ function _cu_test_content_create_slider_field_collection_item($bean, $title, $or
   $fc_item = entity_create('field_collection_item', array('field_name' => 'field_slider_slide'));
   $fc_item->setHostEntity('bean', $bean);
   $text = _cu_test_content_grid_titles_dummy_text();
+  // Add button to slider text
+  $text .= ' [button color="blue" url="node/1"]Learn More[/button]';
   $fc_item->field_slider_caption[LANGUAGE_NONE][$order]['value'] = $title;
   $fc_item->field_slider_teaser[LANGUAGE_NONE][$order]['value'] = $text;
   $fc_item->field_slider_teaser[LANGUAGE_NONE][$order]['format'] = 'wysiwyg';

--- a/modules/custom/cu_test_content_admin_bundle/cu_test_content_context/cu_test_content_context.context.inc
+++ b/modules/custom/cu_test_content_admin_bundle/cu_test_content_context/cu_test_content_context.context.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * cu_test_content_context.context.inc
@@ -11,7 +12,7 @@ function cu_test_content_context_context_default_contexts() {
   $export = array();
 
   $context = new stdClass();
-  $context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+  $context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
   $context->api_version = 3;
   $context->name = 'cu_test_content_article_lists';
   $context->description = '';
@@ -216,6 +217,18 @@ function cu_test_content_context_context_default_contexts() {
           'region' => 'content',
           'weight' => '9',
         ),
+        'bean-content_grid_teaser' => array(
+          'module' => 'bean',
+          'delta' => 'content_grid_teaser',
+          'region' => 'content',
+          'weight' => '10',
+        ),
+        'bean-content_grid_cards' => array(
+          'module' => 'bean',
+          'delta' => 'content_grid_cards',
+          'region' => 'content',
+          'weight' => '10',
+        ),
       ),
     ),
   );
@@ -227,7 +240,7 @@ function cu_test_content_context_context_default_contexts() {
   $export['cu_test_content_blocks'] = $context;
 
   $context = new stdClass();
-  $context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+  $context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
   $context->api_version = 3;
   $context->name = 'cu_test_content_home';
   $context->description = 'Home page test content';
@@ -472,7 +485,7 @@ function cu_test_content_context_context_default_contexts() {
   $export['cu_test_content_home_3'] = $context;
 
   $context = new stdClass();
-  $context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+  $context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
   $context->api_version = 3;
   $context->name = 'cu_test_content_pages';
   $context->description = '';
@@ -519,7 +532,7 @@ function cu_test_content_context_context_default_contexts() {
   $export['cu_test_content_pages'] = $context;
 
   $context = new stdClass();
-  $context->disabled = FALSE; /* Edit this to true to make a default context disabled initially */
+  $context->disabled = TRUE; /* Edit this to true to make a default context disabled initially */
   $context->api_version = 3;
   $context->name = 'cu_test_content_sitewide';
   $context->description = 'Sitewide test content';


### PR DESCRIPTION
To test:

1. Enable cu_test_content_blocks
2. Enable cu_test_content_context
3. Go to /blocks and you should see the updated content grid examples/