### PR TITLE
Bug/414

### DIFF
--- a/modules/contrib/simplesamlphp_auth/express-skip-slo-redirect.patch
+++ b/modules/contrib/simplesamlphp_auth/express-skip-slo-redirect.patch
@@ -1,0 +1,19 @@
+diff --git a/simplesamlphp_auth.module b/simplesamlphp_auth.module
+index b888814..81f30df 100644
+--- a/simplesamlphp_auth.module
++++ b/simplesamlphp_auth.module
+@@ -267,8 +267,12 @@ function simplesamlphp_auth_user_logout($account) {
+   // Allow modules to alter $gotourl.
+   drupal_alter('simplesamlphp_auth_logout_gotourl', $gotourl, $account);
+ 
+-    $_simplesamlphp_auth_as->logout($gotourl);
+-
++    // Express Custom Conditional
++    // If simplesamlphp_auth_slo_redirect is set, then destroy the local session AND redirect to feadauth single logout page
++    // Otherwise, destroy local session only and don't redirect to fedauth single logout page
++    if (variable_get('simplesamlphp_auth_slo_redirect', NULL)) {
++      $_simplesamlphp_auth_as->logout($gotourl);
++    }
+   }
+ }
+ 

--- a/modules/contrib/simplesamlphp_auth/simplesamlphp_auth.module
+++ b/modules/contrib/simplesamlphp_auth/simplesamlphp_auth.module
@@ -267,8 +267,12 @@ function simplesamlphp_auth_user_logout($account) {
   // Allow modules to alter $gotourl.
   drupal_alter('simplesamlphp_auth_logout_gotourl', $gotourl, $account);
 
-    $_simplesamlphp_auth_as->logout($gotourl);
-
+    // Express Custom Conditional
+    // If simplesamlphp_auth_slo_redirect is set, then destroy the local session AND redirect to feadauth single logout page
+    // Otherwise, destroy local session only and don't redirect to fedauth single logout page
+    if (variable_get('simplesamlphp_auth_slo_redirect', NULL)) {
+      $_simplesamlphp_auth_as->logout($gotourl);
+    }
   }
 }
 


### PR DESCRIPTION
Don't redirect users to SLO page unless `simplesamlphp_auth_slo_redirect` is set.

See #414 for implementation and logic behind patch.