### PR TITLE
chg: Redirect user back to homepage after attempting to log into a lo…

### DIFF
--- a/modules/custom/express_content_edit_lock/express_content_edit_lock.module
+++ b/modules/custom/express_content_edit_lock/express_content_edit_lock.module
@@ -237,9 +237,10 @@ function express_content_edit_lock_user_login(&$edit, $account) {
 
     if (!array_key_exists($account->name, $devs) && ($dev_lock === TRUE)) {
       watchdog('express_content_edit_lock', ':name has tried to login to the site while it is locked.', array(':name' => $account->name));
+      module_load_include('pages.inc', 'user');
       user_logout_current_user();
       drupal_set_message('You are not able to login to the site at this time.', 'error');
-      drupal_goto('user');
+      drupal_goto();
     }
   }
 }


### PR DESCRIPTION
…cked site, previously redirected to /user

More details at https://github.com/cuboulder/express_mono/issues/420

**How to Test:**

1. On a express site run `drush vset lock_user_dev TRUE` 
2. Try to log in by going to `/user`
3. You will be redirected to the homepage and will see `You are not able to login to the site at this time.` error banner
