### PR TITLE
chg: update php and drupal versions for Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ git:
   depth: 1
 
 php:
-  - '7.2.25'
+  - '7.2.26'
 
 branches:
   only:

--- a/tests/travis-ci/install.sh
+++ b/tests/travis-ci/install.sh
@@ -11,8 +11,8 @@ earlyexit
 
 # Build Codebase.
 cd $ROOT_DIR
-drush dl drupal-7.68
-mkdir drupal && mv drupal-7.68/* drupal/
+drush dl drupal-7.69
+mkdir drupal && mv drupal-7.69/* drupal/
 mkdir profiles && mv express_mono drupal/profiles/express
 
 # Harden Core.


### PR DESCRIPTION
files updated:
.travis/yml with php version
tests/travis-ci/install.sh with drupal version
