### PR TITLE
Feature/41 531

### DIFF
--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.drush.inc
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.drush.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+* Implements hook_drush_cache_clear().
+*/
+function cu_faculty_publications_bundle_drush_cache_clear(&$types) {
+  $types['cu_faculty_publications_bundle'] = '_cu_faculty_publications_bundle_cache_clear';
+}
+
+/**
+* Utility function that clears all the entries in our cache bin.
+*/
+function _cu_faculty_publications_bundle_cache_clear() {
+  cache_clear_all('*', 'cache_cu_faculty_publications_bundle', true);
+}

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.install
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.install
@@ -4,6 +4,6 @@
   */
 function cu_faculty_publications_bundle_schema() {
   $schema = array();
-  $schema['cu_faculty_publications_bundle'] = drupal_get_schema_unprocessed('system', 'cache');
+  $schema['cache_cu_faculty_publications_bundle'] = drupal_get_schema_unprocessed('system', 'cache');
   return $schema;
 }

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.install
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.install
@@ -1,0 +1,9 @@
+<?php
+/**
+  * Implements hook_schema().
+  */
+function cu_faculty_publications_bundle_schema() {
+  $schema = array();
+  $schema['cu_faculty_publications_bundle'] = drupal_get_schema_unprocessed('system', 'cache');
+  return $schema;
+}

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -171,18 +171,21 @@ function get_publication_data($url) {
   
   if ($cache->data['expiration'] <= time() || !isset($cache->data)) {
     $response = drupal_json_decode(drupal_http_request($url)->data, true);
-    $newData = [
-      'publications' => [
-        'total' => $response['hits']['total'],
-        'results' => $response['hits']['hits'],
-      ],
-      'expiration' => time() + (7 * 24 * 60 * 60)
-    ];
-
-    cache_set($url, $newData);
-
-    if (!isset($cache->data)) {
-      $publications = $newData['publications'];
+    
+    if ($response) {
+      $newData = [
+        'publications' => [
+          'total' => $response['hits']['total'],
+          'results' => $response['hits']['hits'],
+        ],
+        'expiration' => time() + (7 * 24 * 60 * 60)
+      ];
+  
+      cache_set($url, $newData);
+  
+      if (!isset($cache->data)) {
+        $publications = $newData['publications'];
+      }
     }
   }
 

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -1,19 +1,17 @@
 <?php
 
 /**
- * @file
- * Code for the Faculty Publications feature.
- */
-
+  * @file
+  * Code for the Faculty Publications feature.
+  */
 include_once 'cu_faculty_publications_bundle.features.inc';
 
-
 /**
- * Implements hook_theme_registry_alter().
- *
- * Let Drupal know that we've got bean--faculty_publications.tpl.php in our module
- * directory.
- */
+  * Implements hook_theme_registry_alter().
+  *
+  * Let Drupal know that we've got bean--faculty_publications.tpl.php in our module
+  * directory.
+  */
 function cu_faculty_publications_bundle_theme_registry_alter(&$theme_registry) {
   $module_path = drupal_get_path('module', 'cu_faculty_publications_bundle');
   $theme_registry_copy = $theme_registry;
@@ -41,8 +39,11 @@ function cu_faculty_publications_bundle_theme(&$existing, $type, $theme, $path) 
   return $registry;
 }
 
+/**
+  * Implements hook_preprocess_entity().
+  */
 function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
-  $entity_type = $vars['elements']['#entity_type'];
+  // $entity_type = $vars['elements']['#entity_type'];
 
   if ($vars['elements']['#bundle'] == 'faculty_publications') {
 
@@ -158,12 +159,11 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
       }
     }
   }
-  $end = "the end";
 }
 
 function get_publication_data($url) {
   $publications = [];
-  $cache = cache_get($url);
+  $cache = cache_get($url, 'cu_faculty_publications_bundle');
 
   if (isset($cache->data)) {
     $publications = $cache->data['publications'];
@@ -178,18 +178,17 @@ function get_publication_data($url) {
           'total' => $response['hits']['total'],
           'results' => $response['hits']['hits'],
         ],
-        'expiration' => time() + (7 * 24 * 60 * 60)
+        'expiration' => time() + (24 * 60 * 60)
       ];
   
-      cache_set($url, $newData);
-  
+      cache_set($url, $newData, 'cu_faculty_publications_bundle');
       if (!isset($cache->data)) {
         $publications = $newData['publications'];
       }
     }
   }
 
-    return $publications;
+  return $publications;
 }
 
 function cu_faculty_publications_sort() {
@@ -201,10 +200,10 @@ function cu_faculty_publications_results() {
 }
 
 /**
- * Implements hook_secure_permissions().
- *
- * Adding permissions for newsletter
- */
+  * Implements hook_secure_permissions().
+  *
+  * Adding permissions for newsletter
+  */
 function cu_faculty_publications_bundle_secure_permissions($role) {
   $permissions = array(
     'anonymous user' => array(
@@ -249,4 +248,11 @@ function cu_faculty_publications_bundle_secure_permissions($role) {
   if (isset($permissions[$role])) {
     return $permissions[$role];
   }
+}
+
+/**
+  * Implements hook_flush_caches().
+  */
+function cu_faculty_publications_bundle_flush_caches() {
+  return array('cu_faculty_publications_bundle');
 }

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -147,6 +147,10 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
         $totalResults = $publications['total'] > $requestedNumberOfResults ? $requestedNumberOfResults : $publications['total'];
         pager_default_initialize($totalResults, $numberOfResultsPerPage);
 
+        // check if results are from cache;
+        $isFromCache = $publications['isFromCache'] ? "YES" : "NO";
+        $vars['content']['publications'][]['#markup'] = "<!-- Results are from cache: $isFromCache -->";
+
         foreach ($publications['results'] as $item) {
           $vars['content']['publications'][]['#markup'] = theme('faculty_publication', $item['_source']);
         }
@@ -167,6 +171,7 @@ function get_publication_data($url, $cid) {
 
   if (isset($cache->data)) {
     $publications = $cache->data['publications'];
+    $publications['isFromCache'] = true;
   }
   
   if ($cache->data['expiration'] <= time() || !isset($cache->data)) {
@@ -184,6 +189,7 @@ function get_publication_data($url, $cid) {
       cache_set($cid, $newData, 'cache_cu_faculty_publications_bundle');
       if (!isset($cache->data)) {
         $publications = $newData['publications'];
+        $publications['isFromCache'] = false;
       }
     }
   }

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -140,15 +140,13 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
 
     // Send query to facutly publications database and display results.
     if (empty($vars['content']['no_results'])) {
-      $result = drupal_json_decode(drupal_http_request($elasticSearchRequest)->data, true);
+      $publications = get_publication_data($elasticSearchRequest);
 
-      if ($result) {
-        $queryTotal = $result['hits']['total'];
-        $totalResults = $queryTotal > $requestedNumberOfResults ? $requestedNumberOfResults : $queryTotal;
-        $items = $result['hits']['hits'];
+      if ($publications['results']) {
+        $totalResults = $publications['total'] > $requestedNumberOfResults ? $requestedNumberOfResults : $publications['total'];
         pager_default_initialize($totalResults, $numberOfResultsPerPage);
 
-        foreach ($items as $item) {
+        foreach ($publications['results'] as $item) {
           $vars['content']['publications'][]['#markup'] = theme('faculty_publication', $item['_source']);
         }
 
@@ -156,11 +154,39 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
       }
 
       else {
-        $vars['content']['no_results']['#markup'] = 'There are no results for your query.';
+        $vars['content']['no_results']['#markup'] = 'There are no results for your query. Please check your data filters and try again.';
       }
     }
   }
   $end = "the end";
+}
+
+function get_publication_data($url) {
+  $publications = [];
+  $cache = cache_get($url);
+
+  if (isset($cache->data)) {
+    $publications = $cache->data['publications'];
+  }
+  
+  if ($cache->data['expiration'] <= time() || !isset($cache->data)) {
+    $response = drupal_json_decode(drupal_http_request($url)->data, true);
+    $newData = [
+      'publications' => [
+        'total' => $response['hits']['total'],
+        'results' => $response['hits']['hits'],
+      ],
+      'expiration' => time() + (7 * 24 * 60 * 60)
+    ];
+
+    cache_set($url, $newData);
+
+    if (!isset($cache->data)) {
+      $publications = $newData['publications'];
+    }
+  }
+
+    return $publications;
 }
 
 function cu_faculty_publications_sort() {

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -53,7 +53,7 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
     $numberOfResultsPerPage = 25;
     $requestedNumberOfResults = 10;
     $currentPage = pager_find_page();
-
+    $cacheID = current_path() . "?page=" . $currentPage;
     // Check for publication date filter.
     if (!empty($vars['bean']->field_faculty_publication_date)) {
       $date1 = strtotime($vars['bean']->field_faculty_publication_date[LANGUAGE_NONE][0]['value']);
@@ -141,7 +141,7 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
 
     // Send query to facutly publications database and display results.
     if (empty($vars['content']['no_results'])) {
-      $publications = get_publication_data($elasticSearchRequest);
+      $publications = get_publication_data($elasticSearchRequest, $cacheID);
 
       if ($publications['results']) {
         $totalResults = $publications['total'] > $requestedNumberOfResults ? $requestedNumberOfResults : $publications['total'];
@@ -161,9 +161,9 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
   }
 }
 
-function get_publication_data($url) {
+function get_publication_data($url, $cid) {
   $publications = [];
-  $cache = cache_get($url, 'cu_faculty_publications_bundle');
+  $cache = cache_get($cid, 'cu_faculty_publications_bundle');
 
   if (isset($cache->data)) {
     $publications = $cache->data['publications'];
@@ -181,7 +181,7 @@ function get_publication_data($url) {
         'expiration' => time() + (24 * 60 * 60)
       ];
   
-      cache_set($url, $newData, 'cu_faculty_publications_bundle');
+      cache_set($cid, $newData, 'cu_faculty_publications_bundle');
       if (!isset($cache->data)) {
         $publications = $newData['publications'];
       }

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -163,7 +163,7 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
 
 function get_publication_data($url, $cid) {
   $publications = [];
-  $cache = cache_get($cid, 'cu_faculty_publications_bundle');
+  $cache = cache_get($cid, 'cache_cu_faculty_publications_bundle');
 
   if (isset($cache->data)) {
     $publications = $cache->data['publications'];
@@ -181,7 +181,7 @@ function get_publication_data($url, $cid) {
         'expiration' => time() + (24 * 60 * 60)
       ];
   
-      cache_set($cid, $newData, 'cu_faculty_publications_bundle');
+      cache_set($cid, $newData, 'cache_cu_faculty_publications_bundle');
       if (!isset($cache->data)) {
         $publications = $newData['publications'];
       }
@@ -254,5 +254,5 @@ function cu_faculty_publications_bundle_secure_permissions($role) {
   * Implements hook_flush_caches().
   */
 function cu_faculty_publications_bundle_flush_caches() {
-  return array('cu_faculty_publications_bundle');
+  return array('cache_cu_faculty_publications_bundle');
 }


### PR DESCRIPTION
This pr adds caching of publication results, using drupal 7's cache_set and cache_get. 

It uses the full request url as an id for the cache
- for example: "https://experts.colorado.edu/es/fispubs-v1/publication/_search?q=publicationDate%3A%5B2015-12-01%20TO%202020-01-01%5D%20AND%20authors.organization.name%3Amusic&sort=publicationDate%3Adesc&from=0&size=25"

I am thinking about, and am open to suggestions for, using something else as the cache id. It is just that the url is very easy to use as it is already created and _should_ be unique.

#### The algorithm is as follows:
1. Attempt to get something from the cache with the supplied id (the request url)
2. If data is in the cache use it.
3. If there is no data in the cache with that id _**OR**_ if the cached data is older that 24 hours:
    1. make a fresh call to the database with the url
    89. call cache_set(id, freshData)
45. if there was no cached data use the data from this network call.

OK!
        