### PR TITLE
Adding support for multiple byline ids

### DIFF
--- a/modules/features/cu_article/cu_article.module
+++ b/modules/features/cu_article/cu_article.module
@@ -1361,7 +1361,7 @@ function cu_article_block_view($delta = '') {
 
           $query->join("field_data_field_article_byline", "bylines", "n.nid = bylines.entity_id");
           $query->fields('bylines', array('field_article_byline_tid'));
-          $query->condition('bylines.field_article_byline_tid', $tid, '=');
+          $query->condition('bylines.field_article_byline_tid', $tid, 'IN');
           $query->distinct();
           $query->groupBy('n.nid');
           // Display the newest first.


### PR DESCRIPTION
resolves #554

Not a very big pr but it may be big enough. 

#### This is how I tried to verify that this pr works:
1. create a Person content type
1. create 2 Article content types
1. include the Person's name in the bylines of the articles (there is a byline tab under the wysiwyg editor)
1. make sure that the Articles by Person block is enabled ([directions here](https://websupport.colorado.edu/article/249-articles-by-person-block))
1. go to the person's page and see that there is an Articles by Person-name block there
    - check the links to and from the articles
1. edit the Person's name
1. change the byline of one article to the new name
1. go to the person's page and see that there is an Articles by <Person-name> block there with both of the articles
    - check the links to and from the articles, and that both of the bylines' links lead back to the Person