### PR TITLE
Bug/576

### DIFF
--- a/modules/contrib/user_external_invite/user_external_invite.module
+++ b/modules/contrib/user_external_invite/user_external_invite.module
@@ -906,11 +906,14 @@ function _user_external_invite_load_related_invites($entity) {
  * Removes role from invited roles upon deletion.
  */
 function user_external_invite_user_role_delete($role) {
-  $rids = variable_get('user_external_invite_roles', NULL);
+  $rids = variable_get('user_external_invite_core_roles', NULL);
   $removed_id = $role->rid;
-  if (in_array($removed_id, $rids)) {
-    unset($rids[$removed_id]);
-    variable_set('user_external_invite_roles', $rids);
+  for ($index = 0; $index < count($rids); $index++) {
+    if ($rids[$index] == $removed_id) {
+      unset($rids[$index]);
+      variable_set('user_external_invite_core_roles', $rids);
+      break;
+    }
   }
 }
 

--- a/modules/custom/express_permissions/express_permissions.install
+++ b/modules/custom/express_permissions/express_permissions.install
@@ -76,5 +76,13 @@ function express_permissions_update_7010() {
     }
   }
   // Delete the content_editor role.
+  user_role_delete($role);
+}
+
+/**
+ * Complete removal of content_editor role.
+ */
+ function express_permissions_update_7011() {
+  // Delete the content_editor role. Passing in a string this time, as the user_role_delete function expects.
   user_role_delete('content_editor');
 }

--- a/modules/custom/express_permissions/express_permissions.install
+++ b/modules/custom/express_permissions/express_permissions.install
@@ -76,5 +76,5 @@ function express_permissions_update_7010() {
     }
   }
   // Delete the content_editor role.
-  user_role_delete($role);
+  user_role_delete('content_editor');
 }

--- a/modules/custom/express_permissions/express_permissions.install
+++ b/modules/custom/express_permissions/express_permissions.install
@@ -82,7 +82,7 @@ function express_permissions_update_7010() {
 /**
  * Complete removal of content_editor role.
  */
- function express_permissions_update_7011() {
+function express_permissions_update_7011() {
   // Delete the content_editor role. Passing in a string this time, as the user_role_delete function expects.
   user_role_delete('content_editor');
 }


### PR DESCRIPTION
Changed the update methods `express_permissions_update_7010()` and `user_external_invite_user_role_delete($role)` to correctly delete the content_editor role. As it is now we will have to run this update again to get the fix. Is it best to create a new hook_update() function with this code in it to apply this fix? (assuming it works!)

#### To verify this fix I checked:
(this is the tricky bit) Somehow be sure that either you have a non-updated database or that your database went through the update that caused bug #576 and you have a way to rerun the update. If you have all of that ready do these:
1. run `drush updb -y`
1. verify that no warnings or errors show up while the command is running
1. load admin/people and click the second drop down menu under the label **Role**. Make sure content_editor is not in there
1. click the other tabs next to **List** and make sure that content_editor is not present