### PR TITLE
removing cu_sid and cu_path from pathologic string 

### DIFF
--- a/modules/features/cu_wysiwyg/cu_wysiwyg.module
+++ b/modules/features/cu_wysiwyg/cu_wysiwyg.module
@@ -25,7 +25,8 @@ function _create_cu_pathologic_paths() {
   // Use the global base_path and base_url set in bootstrap.inc/drupal_settings_initialize().
   $base_url = $GLOBALS['base_url'];
   $base_path = $GLOBALS['base_path'];
-
+  variable_set('cu_sid', 'p123456789');
+  $cu_sid = variable_get('cu_sid', FALSE);
   $paths = array();
   
   $paths[] = "$base_url/";
@@ -33,6 +34,11 @@ function _create_cu_pathologic_paths() {
   $paths[] = "http://www.colorado.edu$base_path";
   $paths[] = "https://www.colorado.edu$base_path";
   
+  if ($cu_sid) {
+    $paths[] = "/$cu_sid/";
+    $paths[] = "http://www.colorado.edu/$cu_sid/";
+    $paths[] = "https://www.colorado.edu/$cu_sid/";
+  }
   // Build pathologic settings on one path per line
   $all_paths = join("\n", $paths);
   return $all_paths;

--- a/modules/features/cu_wysiwyg/cu_wysiwyg.module
+++ b/modules/features/cu_wysiwyg/cu_wysiwyg.module
@@ -22,7 +22,7 @@ function cu_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
  *   A list of pathologic paths for the current site.
  */
 function _create_cu_pathologic_paths() {
-  // Use the global base_path and base_url set in bootstrap.inc/drupal settings initialize.
+  // Use the global base_path and base_url set in bootstrap.inc/drupal_settings_initialize().
   $base_url = $GLOBALS['base_url'];
   $base_path = $GLOBALS['base_path'];
 
@@ -36,13 +36,6 @@ function _create_cu_pathologic_paths() {
   // Build pathologic settings on one path per line
   $all_paths = join("\n", $paths);
   return $all_paths;
-}
-
-/**
- * Implements Pathologic's hook_pathologic_alter().
- */
-function hook_pathologic_alter(&$url_params, $parts, $settings) {
-  $aPlaceToStop = 'here';
 }
 
 /**

--- a/modules/features/cu_wysiwyg/cu_wysiwyg.module
+++ b/modules/features/cu_wysiwyg/cu_wysiwyg.module
@@ -22,25 +22,28 @@ function cu_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
  *   A list of pathologic paths for the current site.
  */
 function _create_cu_pathologic_paths() {
-  $cu_sid = variable_get('cu_sid', FALSE);
-  $cu_path = variable_get('cu_path', FALSE);
-  if ($cu_sid || $cu_path) {
-    $paths = array();
-    // Build hash paths
-    if ($cu_sid) {
-      $paths[] = "/$cu_sid/";
-      $paths[] = "http://www.colorado.edu/$cu_sid/";
-      $paths[] = "https://www.colorado.edu/$cu_sid/";
-    }
-    // Build real paths
-    if ($cu_path) {
-      $paths[] = "/$cu_path/";
-      $paths[] = "http://www.colorado.edu/$cu_path/";
-      $paths[] = "https://www.colorado.edu/$cu_path/";
-    }
-    // Build pathologic settings on one path per line
-    return $all_paths = join("\n", $paths);
-  }
+  // Use the global base_path and base_url set in bootstrap.inc/drupal settings initialize.
+  $base_url = $GLOBALS['base_url'];
+  $base_path = $GLOBALS['base_path'];
+
+  $paths = array();
+  
+  $paths[] = "$base_url/";
+
+  $paths[] = "/$base_path/";
+  $paths[] = "http://www.colorado.edu/$base_path/";
+  $paths[] = "https://www.colorado.edu/$base_path/";
+  
+  // Build pathologic settings on one path per line
+  $all_paths = join("\n", $paths);
+  return $all_paths;
+}
+
+/**
+ * Implements Pathologic's hook_pathologic_alter().
+ */
+function hook_pathologic_alter(&$url_params, $parts, $settings) {
+  $aPlaceToStop = 'here';
 }
 
 /**

--- a/modules/features/cu_wysiwyg/cu_wysiwyg.module
+++ b/modules/features/cu_wysiwyg/cu_wysiwyg.module
@@ -29,10 +29,9 @@ function _create_cu_pathologic_paths() {
   $paths = array();
   
   $paths[] = "$base_url/";
-
-  $paths[] = "/$base_path/";
-  $paths[] = "http://www.colorado.edu/$base_path/";
-  $paths[] = "https://www.colorado.edu/$base_path/";
+  $paths[] = "$base_path";
+  $paths[] = "http://www.colorado.edu$base_path";
+  $paths[] = "https://www.colorado.edu$base_path";
   
   // Build pathologic settings on one path per line
   $all_paths = join("\n", $paths);

--- a/modules/features/cu_wysiwyg/cu_wysiwyg.module
+++ b/modules/features/cu_wysiwyg/cu_wysiwyg.module
@@ -16,16 +16,16 @@ function cu_wysiwyg_wysiwyg_editor_settings_alter(&$settings, $context) {
 }
 
 /**
- * Saves Pathologic based on each site's site ID.
+ * Saves Pathologic based on each site's base url, base path, and site ID.
  *
  * @return string
  *   A list of pathologic paths for the current site.
  */
 function _create_cu_pathologic_paths() {
   // Use the global base_path and base_url set in bootstrap.inc/drupal_settings_initialize().
+  // Also loading the deprecated $cu_sid, if present, so that a site's old links will still work.
   $base_url = $GLOBALS['base_url'];
   $base_path = $GLOBALS['base_path'];
-  variable_set('cu_sid', 'p123456789');
   $cu_sid = variable_get('cu_sid', FALSE);
   $paths = array();
   


### PR DESCRIPTION
removing $`cu_sid` and `$cu_path` from pathologic string and replacing them with the global variables `$base_url` and `$base_path` which are set in drupal core (bootstrap.inc/drupal_settings_initialize())