### PR TITLE
chg: removing hard coded array of feature names.

### DIFF
--- a/modules/custom/cu_core/cu_core.install
+++ b/modules/custom/cu_core/cu_core.install
@@ -341,22 +341,13 @@ function cu_core_requirements($phase) {
   if ($phase === 'runtime') {
     $t = get_t();
     $overriddenFeatures = array();
-    // This is a way to hard code (almost never the best?) features we know will be overridden.
-    // Just put the sting name of the feature in.
-    $featureStatesToIgnore = [
-      'cu_sitewide',
-      'cu_sitemap',
-      'cu_feature_callout',
-      'cu_social_links',
-      'cu_webform',
-      'cu_mega_menu',
-      'cu_ldap',
-    ];
     // The features.export.inc is where features_get_storage() is defined.
     module_load_include('inc', 'features', 'features.export');
 
+    // This loops over each feature, checking if its state is overridden and if it is expected to be overridden.
+    // If the feature's .info file contains `settings[can_be_overridden] = 1`, it can be overridden and will not show up as an error on the /admin/reports/status page.
     foreach (features_get_features(NULL, TRUE) as $feature) {
-      if (features_get_storage($feature->name) == FEATURES_OVERRIDDEN && !in_array($feature->name, $featureStatesToIgnore)) {
+      if (features_get_storage($feature->name) == FEATURES_OVERRIDDEN && $feature->info['settings']['can_be_overridden'] !== "1") {
         $overriddenFeatures[] = $feature->info['name'];
       }
     }

--- a/modules/custom/cu_mega_menu_bundle/cu_mega_menu/cu_mega_menu.info
+++ b/modules/custom/cu_mega_menu_bundle/cu_mega_menu/cu_mega_menu.info
@@ -25,3 +25,4 @@ features[field_instance][] = mega_menu-mega_menu-field_mega_menu_links
 features[field_instance][] = mega_menu-mega_menu-field_mega_menu_text_above
 features[field_instance][] = mega_menu-mega_menu-field_mega_menu_text_below
 features_exclude[dependencies][eck] = eck
+settings[can_be_overridden] = 1

--- a/modules/custom/cu_sitemap/cu_sitemap.info
+++ b/modules/custom/cu_sitemap/cu_sitemap.info
@@ -19,3 +19,4 @@ features[variable][] = xmlsitemap_regenerate_needed
 features[variable][] = xmlsitemap_settings_menu_link_main-menu
 features[variable][] = xmlsitemap_settings_menu_link_menu-footer-menu
 features[variable][] = xmlsitemap_settings_menu_link_menu-secondary-menu
+settings[can_be_overridden] = 1

--- a/modules/custom/cu_webform/cu_webform.info
+++ b/modules/custom/cu_webform/cu_webform.info
@@ -38,3 +38,4 @@ features[variable][] = node_submitted_webform
 features[variable][] = pathauto_node_webform_pattern
 features[variable][] = recaptcha_secret_key
 features[variable][] = recaptcha_site_key
+settings[can_be_overridden] = 1

--- a/modules/features/cu_feature_callout/cu_feature_callout.info
+++ b/modules/features/cu_feature_callout/cu_feature_callout.info
@@ -42,3 +42,4 @@ features_exclude[field][bean-feature_callout-field_callout_image_size] = bean-fe
 features_exclude[field][field_collection_item-field_callouts-field_callout_image] = field_collection_item-field_callouts-field_callout_image
 features_exclude[field][field_collection_item-field_callouts-field_callout_text] = field_collection_item-field_callouts-field_callout_text
 features_exclude[field][field_collection_item-field_callouts-field_callout_title] = field_collection_item-field_callouts-field_callout_title
+settings[can_be_overridden] = 1

--- a/modules/features/cu_ldap/cu_ldap.info
+++ b/modules/features/cu_ldap/cu_ldap.info
@@ -26,3 +26,4 @@ features[variable][] = ldap_servers_require_ssl_for_credentails
 features[variable][] = ldap_servers_require_ssl_for_credentials
 features[variable][] = ldap_user_cron
 features[variable][] = realname_pattern
+settings[can_be_overridden] = 1

--- a/modules/features/cu_sitewide/cu_sitewide.info
+++ b/modules/features/cu_sitewide/cu_sitewide.info
@@ -12,3 +12,4 @@ features[context][] = sitewide
 features[context][] = sitewide-except-homepage
 features[ctools][] = context:context:3
 features[features_api][] = api:2
+settings[can_be_overridden] = 1

--- a/modules/features/cu_social_links/cu_social_links.info
+++ b/modules/features/cu_social_links/cu_social_links.info
@@ -30,3 +30,4 @@ features[field_instance][] = bean-social_links-field_social_links_homepage_url
 features[field_instance][] = bean-social_links-field_social_links_size
 features[field_instance][] = field_collection_item-field_social_links_collection-field_social_link_type
 features[field_instance][] = field_collection_item-field_social_links_collection-field_social_link_url
+settings[can_be_overridden] = 1


### PR DESCRIPTION
Some features we expect to be overridden and do not need or want them to show up as errors in a site's admin/reports/status page. Previously, we just hard coded a list of feature machine names to ignore to achieve this. Now, I have added `settings[can_be_overridden] = 1` to the .info files of these features. The code in the `cu_core_requirements()` function now checks for that property before adding a feature name to the admin/reports/status page.