### PR TITLE
added 'settings[can_be_overridden] to .info file

### DIFF
--- a/modules/features/cu_linkchecker/cu_linkchecker.info
+++ b/modules/features/cu_linkchecker/cu_linkchecker.info
@@ -31,3 +31,4 @@ features[variable][] = linkchecker_scan_beans
 features[variable][] = linkchecker_scan_blocks
 features[variable][] = linkchecker_scan_comments
 features[variable][] = linkchecker_scan_nodetypes
+settings[can_be_overridden] = 1


### PR DESCRIPTION
Should fix #602. cu_linkchecker should not appear in the overridden features list found on admin/reports/status