### PR TITLE
default_home_page (aka cu_home_page) don't show override

### DIFF
--- a/modules/features/cu_home_page/cu_home_page.info
+++ b/modules/features/cu_home_page/cu_home_page.info
@@ -15,3 +15,4 @@ features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
 features[menu_custom][] = main-menu
 features_exclude[dependencies][ctools] = ctools
+settings[can_be_overridden] = 1


### PR DESCRIPTION
A quick pr to ignore the fact that cu_homepage is often overridden.