### PR TITLE
added settings[can_be_overridden] = 1 to .info file.

### DIFF
--- a/modules/features/cu_googleanalytics/cu_googleanalytics.info
+++ b/modules/features/cu_googleanalytics/cu_googleanalytics.info
@@ -31,3 +31,4 @@ features[variable][] = googleanalytics_trackoutbound
 features[variable][] = googleanalytics_trackoutboundaspageview
 features[variable][] = googleanalytics_visibility_pages
 features[variable][] = googleanalytics_visibility_roles
+settings[can_be_overridden] = 1


### PR DESCRIPTION
cu_analytics feature should now not be shown on the /admin/reports/status page when it is overridden as expected.