### PR TITLE
CU Drupal7 Core for Travis tests

### DIFF
--- a/tests/travis-ci/install.sh
+++ b/tests/travis-ci/install.sh
@@ -11,7 +11,7 @@ earlyexit
 
 # Build Codebase.
 cd $ROOT_DIR
-git clone https://github.com/CuBoulder/d7core.git drupal
+git clone --depth 1 https://github.com/CuBoulder/d7core.git drupal
 mkdir profiles && mv express_mono drupal/profiles/express
 
 # Harden Core.

--- a/tests/travis-ci/install.sh
+++ b/tests/travis-ci/install.sh
@@ -11,8 +11,7 @@ earlyexit
 
 # Build Codebase.
 cd $ROOT_DIR
-drush dl drupal-7.72
-mkdir drupal && mv drupal-7.72/* drupal/
+git clone https://github.com/CuBoulder/d7core.git drupal
 mkdir profiles && mv express_mono drupal/profiles/express
 
 # Harden Core.


### PR DESCRIPTION
Closes #569 

Stop using Drupal 7 from Drupal.org and use CU's hardened Drupal 7 core instead.