### PR TITLE
chg: initialize disabled form counting variable as array !minor

### DIFF
--- a/modules/custom/cu_unused_forms/cu_unused_forms.module
+++ b/modules/custom/cu_unused_forms/cu_unused_forms.module
@@ -54,7 +54,7 @@ function cu_unused_forms_list() {
   }
   // Load all the webform nids to use later on.
   $nodes = node_load_multiple($form_nids);
-  $disabled_count = NULL;
+  $disabled_count = array();
   foreach ($nodes as $node) {
     if ($node->webform['status'] == 0) {
       $disabled_count[] = $node;


### PR DESCRIPTION
Solves #566 
warning: count(): Parameter must be an array or an object that implements [warning] Countable Table.php:789

In production, this error is generated by the Unused Webforms Forms report. It happens on sites that have no disabled forms. The solution is to initialize the Disabled Forms counter as an array, not as NULL. 

(Locally, update Drush to version 8.x) 

<img width="421" alt="Screen Shot 2020-09-03 at 3 32 29 PM" src="https://user-images.githubusercontent.com/638275/92176118-0f732500-edfb-11ea-9498-595452f8b7ad.png">
