### PR TITLE
Fix for counter.js used in the countup shortcode. Resolves #637

### DIFF
--- a/modules/custom/cu_shortcodes/js/counter.js
+++ b/modules/custom/cu_shortcodes/js/counter.js
@@ -17,7 +17,7 @@
             var t = e(this),
                 r = n,
                 i = function() {
-                    var e = [],
+                    var e = [t.text()],
                         n = r.time / r.delay,
                         i = t.text(),
                         s = /[0-9]+,[0-9]+/.test(i);


### PR DESCRIPTION
A little fix is all that was needed, for now.


![countup](https://user-images.githubusercontent.com/23508839/94319410-cde02080-ff47-11ea-92d8-90a0990f9ff1.gif)
