### PR TITLE
new: created block to be inserted on Person pages. Resolves #643

### DIFF
--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.install
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.install
@@ -13,3 +13,19 @@ function cu_faculty_publications_bundle_schema() {
   $schema['cache_cu_faculty_publications_bundle'] = drupal_get_schema_unprocessed('system', 'cache');
   return $schema;
 }
+
+/**
+ * Implements hook_install()
+ */
+function cu_faculty_publications_bundle_install() {
+  variable_set('person_publications_list_order', 'date-desc');
+  variable_set('person_publications_list_number', 5);
+}
+
+/**
+ * Implements hook_unintstall()
+ */
+function cu_faculty_publications_bundle_uninstall() {
+  variable_del('person_publications_list_order');
+  variable_del('person_publications_list_number');
+}

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.install
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.install
@@ -20,6 +20,7 @@ function cu_faculty_publications_bundle_schema() {
 function cu_faculty_publications_bundle_install() {
   variable_set('person_publications_list_order', 'date-desc');
   variable_set('person_publications_list_number', 5);
+  variable_set('all_publications_list_order', 'date-desc');
 }
 
 /**
@@ -28,4 +29,5 @@ function cu_faculty_publications_bundle_install() {
 function cu_faculty_publications_bundle_uninstall() {
   variable_del('person_publications_list_order');
   variable_del('person_publications_list_number');
+  variable_del('all_publications_list_order');
 }

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -59,27 +59,27 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
     case 'person_publications_list':
       $block = array();
 
-      $nodePath = drupal_get_normal_path($_GET['q']);
-      $node = node_load(explode('/', $nodePath)[1]);
-      $skipCache = user_access('edit any faculty_publications bean');
-
-      $order = variable_get('person_publications_list_order', 'date-desc');
-      $number = variable_get('person_publications_list_number', 5);
-      $fakeBeanObject = new stdClass();
-      $fakeBeanObject->field_faculty_publication_email = $node->field_person_email;
-      $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
-      $fakeBeanObject->field_faculty_pub_results = [LANGUAGE_NONE => [0 => ['value' => $number]]];
-
-      $publicationData = get_publication_data($nodePath, $skipCache, $fakeBeanObject);
-
-      if (!$skipCache && !$publicationData['results']) {
-        return $block;
-      }
-
-      else {
-        $block['subject'] = 'Recent Publications:';
-        $block['content'] = publish_data($publicationData);
-        return $block;
+      if (($node = menu_get_object()) && ($node->type == 'person')) {
+        $skipCache = user_access('edit any faculty_publications bean');
+  
+        $order = variable_get('person_publications_list_order', 'date-desc');
+        $number = variable_get('person_publications_list_number', 5);
+        $fakeBeanObject = new stdClass();
+        $fakeBeanObject->field_faculty_publication_email = $node->field_person_email;
+        $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
+        $fakeBeanObject->field_faculty_pub_results = [LANGUAGE_NONE => [0 => ['value' => $number]]];
+  
+        $publicationData = get_publication_data($node->title, $skipCache, $fakeBeanObject);
+  
+        if (!$skipCache && !$publicationData['results']) {
+          return $block;
+        }
+  
+        else {
+          $block['subject'] = 'Recent Publications:';
+          $block['content'] = publish_data($publicationData);
+          return $block;
+        }
       }
       break;
 

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -43,7 +43,7 @@ function cu_faculty_publications_bundle_theme(&$existing, $type, $theme, $path) 
 /**
  * Implements hook_block_info().
  */
- function cu_faculty_publications_bundle_block_info() {
+function cu_faculty_publications_bundle_block_info() {
   return array(
     'person_publications_list' => array(
       'info' => t("Person Publications List")
@@ -69,7 +69,7 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
       $fakeBeanObject->field_faculty_publication_email = $node->field_person_email;
       $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
       $fakeBeanObject->field_faculty_pub_results = [LANGUAGE_NONE => [0 => ['value' => $number]]];
-      
+
       $publicationData = get_publication_data($nodePath, $skipCache, $fakeBeanObject);
 
       if (!$skipCache && !$publicationData['results']) {
@@ -82,7 +82,7 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
         return $block;
       }
       break;
-    
+
     default:
       break;
   }
@@ -90,9 +90,9 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
 
 /**
  * Implements hook_block_configure().
- * The block can be inserted using Context module and configured at /admin/structure/block/manage/cu_faculty_publications_bundle/person_publications_list/configure.
  */
 function cu_faculty_publications_bundle_block_configure($delta = '') {
+  // The block can be inserted using Context module and configured at /admin/structure/block/manage/cu_faculty_publications_bundle/person_publications_list/configure.
   switch ($delta) {
     case 'person_publications_list':
       $form = array(
@@ -261,8 +261,11 @@ function get_publication_data($cid, $skipCache, $beanObject) {
 /**
  * This is where the request for elastic search is constructed.
  *
- * @param type $publicationData Results from either the cache or requesting experts.colorado.edu.
- * @return array Returns an associative render array passed on to the user interface.
+ * @param array
+ * $publicationData Results from either the cache or requesting experts.colorado.edu.
+ *
+ * @return array
+ * Returns an associative render array passed on to the user interface.
  */
 function publish_data($publicationData) {
   $output = array();
@@ -393,12 +396,12 @@ function build_request_data($beanObject) {
     $numberOfResults = $beanObject->field_faculty_pub_results[LANGUAGE_NONE][0]['value'];
     $offset = $currentPage * $numberOfResultsPerPage;
     $arguments['from'] = $offset;
-    
+
     if ($numberOfResults === 'all') {
       // 10,000 search results is the default maximum amount of Elastic Search results.
       $requestedNumberOfResults = 10000;
     }
-    
+
     elseif ($num = intval($numberOfResults)) {
       $requestedNumberOfResults = $num;
     }
@@ -416,7 +419,12 @@ function build_request_data($beanObject) {
 
   // Form the final request url.
   $elasticSearchRequest = url($fisPubsEndpoint, ['query' => $arguments]);
-  return ['reqUrl' => $elasticSearchRequest, 'requestedNumberOfResults' => $requestedNumberOfResults, 'numberOfResultsPerPage' => $numberOfResultsPerPage, 'messages' => $messages];
+  return [
+    'reqUrl' => $elasticSearchRequest,
+    'requestedNumberOfResults' => $requestedNumberOfResults,
+    'numberOfResultsPerPage' => $numberOfResultsPerPage,
+    'messages' => $messages
+  ];
 }
 
 function get_array_from_field_data($fieldArray, $fieldArrayFinalIdentifier) {
@@ -530,7 +538,6 @@ function cu_faculty_publications_sort() {
 function cu_faculty_publications_results() {
   return array('25' => '25', '50' => '50' , '100' => '100', 'all' => 'ALL');
 }
-
 
 /**
  * Implements hook_secure_permissions().

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -28,6 +28,39 @@ function cu_faculty_publications_bundle_theme_registry_alter(&$theme_registry) {
 }
 
 /**
+ * Implements hook_menu().
+ */
+function cu_faculty_publications_bundle_menu() {
+  $items = array();
+  $items['publications/%/all'] = array(
+    'title' => 'All Publications',
+    'description' => 'List of all of a particular faculty member\'s publications',
+    'page callback' => 'person_publications_list_all_page',
+    'page arguments' => array(1),
+    'access callback' => TRUE
+  );
+  return $items;
+}
+
+function person_publications_list_all_page($person_name) {
+  $order = variable_get('all_publications_list_order', 'date-desc');
+  $fakeBeanObject = new stdClass();
+  $fakeBeanObject->field_faculty_publication_email = [LANGUAGE_NONE => [0 => ['email' => $_GET['email']]]];
+  $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
+  $fakeBeanObject->field_faculty_pub_results = [LANGUAGE_NONE => [0 => ['value' => 'all']]];
+
+  $publicationData = get_publication_data(NULL, TRUE, $fakeBeanObject);
+
+  return [
+    'name' => [
+      '#type' => 'markup',
+      '#markup' => l("<h3>{$person_name}</h3>", "{$_GET['return_url']}", ['html' => TRUE])
+    ],
+    'content' => publish_data($publicationData)
+  ];
+}
+
+/**
  * Implements hook_theme().
  */
 function cu_faculty_publications_bundle_theme(&$existing, $type, $theme, $path) {
@@ -78,6 +111,25 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
         else {
           $block['subject'] = 'Recent Publications:';
           $block['content'] = publish_data($publicationData);
+
+          // Show a link to another page if person has more publications than shown here.
+          if ($number < $publicationData['total']) {
+            $link_url = "publications/{$node->title}/all";
+            $link_query_params = [
+              'query' => [
+                'email' => $node->field_person_email[LANGUAGE_NONE][0]['email'],
+                'return_url' => "node/{$node->nid}",
+              ]
+            ];
+
+            $block['content']['full_list_link'] = array(
+              '#type' => 'markup',
+              '#markup' => l("See a full list of {$node->title}'s publications", $link_url, $link_query_params),
+              '#prefix' => '<div>',
+              '#suffix' => '</div>'
+            );
+          }
+
           return $block;
         }
       }
@@ -99,15 +151,22 @@ function cu_faculty_publications_bundle_block_configure($delta = '') {
         'order' => array(
           '#type' => 'select',
           '#options' => array('date-desc' => 'Newest to Oldest', 'date-asc' => 'Oldest to Newest'),
-          '#title' => t('Order of Publications'),
+          '#title' => t('Order of Publications on Person page'),
           '#description' => t('Select the order you wish the results to be shown.'),
           '#default_value' => variable_get('person_publications_list_order', array('date-desc' => 'Newest to Oldest'))
         ),
         'number' => array(
           '#type' => 'textfield',
           '#description' => t('Type how many publications you would like to be listed on a Person page. Will only be saved if numerals are used.'),
-          '#title' => t('Number of Publications'),
+          '#title' => t('Number of Publications on Person page'),
           '#default_value' => variable_get('person_publications_list_number', 5)
+        ),
+        'order_all' => array(
+          '#type' => 'select',
+          '#options' => array('date-desc' => 'Newest to Oldest', 'date-asc' => 'Oldest to Newest'),
+          '#title' => t('Order of Publications on All Publications page'),
+          '#description' => t('Select the order you wish the results to be shown when listing all of a Person\'s publications.'),
+          '#default_value' => variable_get('all_publications_list_order', array('date-desc' => 'Newest to Oldest'))
         )
       );
 
@@ -129,6 +188,7 @@ function cu_faculty_publications_bundle_block_save($delta = '', $edit = array())
       }
 
       variable_set('person_publications_list_order', $edit['order']);
+      variable_set('all_publications_list_order', $edit['order_all']);
       break;
 
     default:
@@ -386,7 +446,7 @@ function build_request_data($beanObject) {
     return $orcidResults;
   }
 
-  elseif (isset($orcidResults) && count($orcidResults['authorsNotFound'] > 0)) {
+  elseif (isset($orcidResults) && count($orcidResults['authorsNotFound']) > 0) {
     $messages['authorsNotFound'] = get_html_no_result_string($orcidResults['authorsNotFound'], 'publications');;
   }
 

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -75,7 +75,7 @@ function person_publications_list_all_page($person_nid) {
     return [
       'name' => [
         '#type' => 'markup',
-        '#markup' => l("return to {$person->title}'s page", "node/{$person->nid}", ['attributes' => ['class' => ['breadcrumb']]]),
+        '#markup' => l("return to {$person->title}'s page", "node/{$person->nid}", ['attributes' => ['class' => ['small-text']]]),
         '#prefix' => '<p>',
         '#suffix' => '</p>'
       ],
@@ -151,7 +151,7 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
 
             $block['content']['full_list_link'] = array(
               '#type' => 'markup',
-              '#markup' => l("See a full list of {$node->title}'s publications", $link_url, ['attributes' => ['class' => ['breadcrumb']]]),
+              '#markup' => l("See a full list of {$node->title}'s publications", $link_url, ['attributes' => ['class' => ['small-text']]]),
               '#prefix' => '<div>',
               '#suffix' => '</div>'
             );

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -61,20 +61,20 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
 
       if (($node = menu_get_object()) && ($node->type == 'person')) {
         $skipCache = user_access('edit any faculty_publications bean');
-  
+
         $order = variable_get('person_publications_list_order', 'date-desc');
         $number = variable_get('person_publications_list_number', 5);
         $fakeBeanObject = new stdClass();
         $fakeBeanObject->field_faculty_publication_email = $node->field_person_email;
         $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
         $fakeBeanObject->field_faculty_pub_results = [LANGUAGE_NONE => [0 => ['value' => $number]]];
-  
+
         $publicationData = get_publication_data($node->title, $skipCache, $fakeBeanObject);
-  
+
         if (!$skipCache && !$publicationData['results']) {
           return $block;
         }
-  
+
         else {
           $block['subject'] = 'Recent Publications:';
           $block['content'] = publish_data($publicationData);

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -75,7 +75,7 @@ function person_publications_list_all_page($person_nid) {
     return [
       'name' => [
         '#type' => 'markup',
-        '#markup' => l("return to {$person->title}'s page", "node/{$person->nid}", ['attributes' => ['class' => ['small-text']]]),
+        '#markup' => l("Return to {$person->title}'s page", "node/{$person->nid}", ['attributes' => ['class' => ['small-text']]]),
         '#prefix' => '<p>',
         '#suffix' => '</p>'
       ],

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -156,10 +156,14 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
  * This function decides where to get data from. Whether to gather it from the module's cache, refresh the data from cache or to gather it from fresh requests to our experts' databases.
  * The publication data or errors/warnings are passed on to the UI.
  *
- * @param string $cid This is the url to this page/node being displayed
- * @param boolean $skipCache This is set based on a user's permissions so that an editor can see their changes and not what has been cached previously.
- * @param object $beanObject This is the object with the form data needed form this block.
- * @return array An associative array with data to pass on to the UI.
+ * @param string $cid
+ *   This is the url to this page/node being displayed or the Person node's name.
+ * @param boolean $skipCache
+ *   This is set based on a user's permissions so that an editor can see their changes and not what has been cached previously.
+ * @param object $beanObject
+ *   This is the object with the form data needed for this block.
+ * @return array
+ *   An associative array with data to pass on to the UI.
  *
  */
 function get_publication_data($cid, $skipCache, $beanObject) {
@@ -261,11 +265,11 @@ function get_publication_data($cid, $skipCache, $beanObject) {
 /**
  * This is where the request for elastic search is constructed.
  *
- * @param array
- * $publicationData Results from either the cache or requesting experts.colorado.edu.
+ * @param array $publicationData
+ *   Results from either the cache or requesting experts.colorado.edu as returned by get_publication_data().
  *
  * @return array
- * Returns an associative render array passed on to the user interface.
+ *   Returns an associative render array passed on to the user interface.
  */
 function publish_data($publicationData) {
   $output = array();
@@ -307,8 +311,10 @@ function publish_data($publicationData) {
 /**
  * This is where the request for elastic search is constructed.
  *
- * @param type $beanObject This is the object containing all data passed in from the form.
- * @return array Returns an associative array with data to pass back into get_publication_data().
+ * @param object $beanObject
+ *   This is the object containing all data passed in from the form.
+ * @return array
+ *   Returns an associative array with data to pass back into get_publication_data().
  */
 function build_request_data($beanObject) {
   $fisPubsEndpoint = variable_get('cu_faculty_publications_endpoint', 'https://experts.colorado.edu/es/fispubs-v1/publication/_search');

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -32,7 +32,7 @@ function cu_faculty_publications_bundle_theme_registry_alter(&$theme_registry) {
  */
 function cu_faculty_publications_bundle_menu() {
   $items = array();
-  $items['publications/%/all'] = array(
+  $items['faculty-publications/%'] = array(
     'title' => 'All Publications',
     'description' => 'List of all of a particular faculty member\'s publications',
     'page callback' => 'person_publications_list_all_page',
@@ -42,22 +42,33 @@ function cu_faculty_publications_bundle_menu() {
   return $items;
 }
 
-function person_publications_list_all_page($person_name) {
+function person_publications_list_all_page($person_nid) {
   $order = variable_get('all_publications_list_order', 'date-desc');
-  $fakeBeanObject = new stdClass();
-  $fakeBeanObject->field_faculty_publication_email = [LANGUAGE_NONE => [0 => ['email' => $_GET['email']]]];
-  $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
-  $fakeBeanObject->field_faculty_pub_results = [LANGUAGE_NONE => [0 => ['value' => 'all']]];
+  if ($person = node_load($person_nid) && $person->type == 'person') {
+    $fakeBeanObject = new stdClass();
+    $fakeBeanObject->field_faculty_publication_email = $person->field_person_email;
+    $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
+    $fakeBeanObject->field_faculty_pub_results = [LANGUAGE_NONE => [0 => ['value' => 'all']]];
 
-  $publicationData = get_publication_data(NULL, TRUE, $fakeBeanObject);
+    $publicationData = get_publication_data(NULL, TRUE, $fakeBeanObject);
 
-  return [
-    'name' => [
-      '#type' => 'markup',
-      '#markup' => l("<h3>{$person_name}</h3>", "{$_GET['return_url']}", ['html' => TRUE])
-    ],
-    'content' => publish_data($publicationData)
-  ];
+    return [
+      'name' => [
+        '#type' => 'markup',
+        '#markup' => l("<h3>{$person->title}</h3>", "node/{$person->nid}", ['html' => TRUE])
+      ],
+      'content' => publish_data($publicationData)
+    ];
+  }
+
+  else {
+    return [
+      'content' => [
+        '#type' => 'markup',
+        '#markup' => "<div class=\"messages warning\">$person_nid: No publications associated with this node"
+      ]
+    ];
+  }
 }
 
 /**
@@ -114,17 +125,11 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
 
           // Show a link to another page if person has more publications than shown here.
           if ($number < $publicationData['total']) {
-            $link_url = "publications/{$node->title}/all";
-            $link_query_params = [
-              'query' => [
-                'email' => $node->field_person_email[LANGUAGE_NONE][0]['email'],
-                'return_url' => "node/{$node->nid}",
-              ]
-            ];
+            $link_url = "faculty-publications/{$node->nid}";
 
             $block['content']['full_list_link'] = array(
               '#type' => 'markup',
-              '#markup' => l("See a full list of {$node->title}'s publications", $link_url, $link_query_params),
+              '#markup' => l("See a full list of {$node->title}'s publications", $link_url),
               '#prefix' => '<div>',
               '#suffix' => '</div>'
             );
@@ -472,7 +477,7 @@ function build_request_data($beanObject) {
       $requestedNumberOfResults = $num;
     }
 
-    $arguments['size'] = $requestedNumberOfResults;
+    $arguments['size'] = $numberOfResultsPerPage;
   }
 
   // Convert all 'q' arguments to a string joined by ' AND ' operator.

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -42,6 +42,9 @@ function cu_faculty_publications_bundle_menu() {
   return $items;
 }
 
+/**
+ * Creates view for complete listing of a faculty member's publications at the url 'faculty-publications/[$person node id number].
+ */
 function person_publications_list_all_page($person_nid) {
   $person = node_load($person_nid);
   if ($person && $person->type == 'person') {
@@ -224,10 +227,11 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
  *
  * @param string $cid
  *   This is the url to this page/node being displayed or the Person node's name.
- * @param boolean $skipCache
+ * @param bool $skipCache
  *   This is set based on a user's permissions so that an editor can see their changes and not what has been cached previously.
  * @param object $beanObject
  *   This is the object with the form data needed for this block.
+ *
  * @return array
  *   An associative array with data to pass on to the UI.
  *
@@ -337,7 +341,7 @@ function get_publication_data($cid, $skipCache, $beanObject) {
  * @return array
  *   Returns an associative render array passed on to the user interface.
  */
-function publish_data($publicationData) {
+function publish_data(array $publicationData) {
   $output = array();
   if (isset($publicationData['error'])) {
     $output['error'][]['#markup'] = $publicationData['error'];
@@ -379,6 +383,7 @@ function publish_data($publicationData) {
  *
  * @param object $beanObject
  *   This is the object containing all data passed in from the form.
+ *
  * @return array
  *   Returns an associative array with data to pass back into get_publication_data().
  */

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -41,6 +41,102 @@ function cu_faculty_publications_bundle_theme(&$existing, $type, $theme, $path) 
 }
 
 /**
+ * Implements hook_block_info().
+ */
+ function cu_faculty_publications_bundle_block_info() {
+  return array(
+    'person_publications_list' => array(
+      'info' => t("Person Publications List")
+    )
+  );
+}
+
+/**
+ * Implements hook_block_view().
+ */
+function cu_faculty_publications_bundle_block_view($delta = '') {
+  switch ($delta) {
+    case 'person_publications_list':
+      $block = array();
+
+      $nodePath = drupal_get_normal_path($_GET['q']);
+      $node = node_load(explode('/', $nodePath)[1]);
+      $skipCache = user_access('edit any faculty_publications bean');
+
+      $order = variable_get('person_publications_list_order', 'date-desc');
+      $number = variable_get('person_publications_list_number', 5);
+      $fakeBeanObject = new stdClass();
+      $fakeBeanObject->field_faculty_publication_email = $node->field_person_email;
+      $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
+      $fakeBeanObject->field_faculty_pub_results = [LANGUAGE_NONE => [0 => ['value' => $number]]];
+      
+      $publicationData = get_publication_data($nodePath, $skipCache, $fakeBeanObject);
+
+      if (!$skipCache && !$publicationData['results']) {
+        return $block;
+      }
+
+      else {
+        $block['subject'] = 'Recent Publications:';
+        $block['content'] = publish_data($publicationData);
+        return $block;
+      }
+      break;
+    
+    default:
+      break;
+  }
+}
+
+/**
+ * Implements hook_block_configure().
+ * The block can be inserted using Context module and configured at /admin/structure/block/manage/cu_faculty_publications_bundle/person_publications_list/configure.
+ */
+function cu_faculty_publications_bundle_block_configure($delta = '') {
+  switch ($delta) {
+    case 'person_publications_list':
+      $form = array(
+        'order' => array(
+          '#type' => 'select',
+          '#options' => array('date-desc' => 'Newest to Oldest', 'date-asc' => 'Oldest to Newest'),
+          '#title' => t('Order of Publications'),
+          '#description' => t('Select the order you wish the results to be shown.'),
+          '#default_value' => variable_get('person_publications_list_order', array('date-desc' => 'Newest to Oldest'))
+        ),
+        'number' => array(
+          '#type' => 'textfield',
+          '#description' => t('Type how many publications you would like to be listed on a Person page. Will only be saved if numerals are used.'),
+          '#title' => t('Number of Publications'),
+          '#default_value' => variable_get('person_publications_list_number', 5)
+        )
+      );
+
+      return $form;
+
+    default:
+      break;
+  }
+}
+
+/**
+ * Implements hook_block_save().
+ */
+function cu_faculty_publications_bundle_block_save($delta = '', $edit = array()) {
+  switch ($delta) {
+    case 'person_publications_list':
+      if ($num = intval($edit['number'])) {
+        variable_set('person_publications_list_number', $num);
+      }
+
+      variable_set('person_publications_list_order', $edit['order']);
+      break;
+
+    default:
+      break;
+  }
+}
+
+/**
  * Implements hook_preprocess_entity().
  */
 function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
@@ -52,37 +148,7 @@ function cu_faculty_publications_bundle_preprocess_entity(&$vars) {
 
     $publicationData = get_publication_data($cid, $skipCache, $vars['bean']);
 
-    if (isset($publicationData['error'])) {
-      $vars['content']['error'][]['#markup'] = $publicationData['error'];
-    }
-
-    else {
-      if ($publicationData['messages']) {
-        foreach ($publicationData['messages'] as $message) {
-          $vars['content']['messages'][]['#markup'] = $message;
-        }
-      }
-
-      if ($publicationData['results']) {
-        $totalResults = $publicationData['total'] > $publicationData['requestedNumberOfResults'] ? $publicationData['requestedNumberOfResults'] : $publicationData['total'];
-        pager_default_initialize($totalResults, 25);
-
-        // Check if results are from cache.
-        // Put in an HTML comment to confirm if results are from cache or not.
-        $isFromCache = $publicationData['isFromCache'] ? "YES" : "NO";
-        $vars['content']['publications'][]['#markup'] = "<!-- Publication data are from cache: $isFromCache -->";
-
-        foreach ($publicationData['results'] as $item) {
-          $vars['content']['publications'][]['#markup'] = theme('faculty_publication', $item['_source']);
-        }
-
-        $vars['content']['publications'][]['#markup'] = theme('pager');
-      }
-
-      else {
-        $vars['content']['no_results'][]['#markup'] = '<h4>There are no results for your query. Please check your data filters and try again.</h4>';
-      }
-    }
+    $vars['content'] = publish_data($publicationData);
   }
 }
 
@@ -166,6 +232,7 @@ function get_publication_data($cid, $skipCache, $beanObject) {
           'total' => $parsedResponse['hits']['total'],
           'results' => $parsedResponse['hits']['hits'],
           'requestedNumberOfResults' => $reqData['requestedNumberOfResults'],
+          'numberOfResultsPerPage' => $reqData['numberOfResultsPerPage'],
           'expiration' => $newExpiration,
           'reqUrl' => $reqData['reqUrl'],
           'messages' => $reqData['messages']
@@ -189,6 +256,49 @@ function get_publication_data($cid, $skipCache, $beanObject) {
       }
     }
   }
+}
+
+/**
+ * This is where the request for elastic search is constructed.
+ *
+ * @param type $publicationData Results from either the cache or requesting experts.colorado.edu.
+ * @return array Returns an associative render array passed on to the user interface.
+ */
+function publish_data($publicationData) {
+  $output = array();
+  if (isset($publicationData['error'])) {
+    $output['error'][]['#markup'] = $publicationData['error'];
+  }
+
+  else {
+    if ($publicationData['messages']) {
+      foreach ($publicationData['messages'] as $message) {
+        $output['messages'][]['#markup'] = $message;
+      }
+    }
+
+    if ($publicationData['results']) {
+      $totalResults = $publicationData['total'] > $publicationData['requestedNumberOfResults'] ? $publicationData['requestedNumberOfResults'] : $publicationData['total'];
+      pager_default_initialize($totalResults, $publicationData['numberOfResultsPerPage']);
+
+      // Check if results are from cache.
+      // Put in an HTML comment to confirm if results are from cache or not.
+      $isFromCache = $publicationData['isFromCache'] ? "YES" : "NO";
+      $output['publications'][]['#markup'] = "<!-- Publication data are from cache: $isFromCache -->";
+
+      foreach ($publicationData['results'] as $item) {
+        $output['publications'][]['#markup'] = theme('faculty_publication', $item['_source']);
+      }
+
+      $output['publications'][]['#markup'] = theme('pager');
+    }
+
+    else {
+      $output['no_results'][]['#markup'] = '<h4>There are no results for your query. Please check your data filters and try again.</h4>';
+    }
+  }
+
+  return $output;
 }
 
 /**
@@ -267,7 +377,7 @@ function build_request_data($beanObject) {
     return $orcidResults;
   }
 
-  elseif (isset($orcidResults) && count($orcidResults['notFound'] > 0)) {
+  elseif (isset($orcidResults) && count($orcidResults['authorsNotFound'] > 0)) {
     $messages['authorsNotFound'] = get_html_no_result_string($orcidResults['authorsNotFound'], 'publications');;
   }
 
@@ -283,16 +393,17 @@ function build_request_data($beanObject) {
     $numberOfResults = $beanObject->field_faculty_pub_results[LANGUAGE_NONE][0]['value'];
     $offset = $currentPage * $numberOfResultsPerPage;
     $arguments['from'] = $offset;
-    $arguments['size'] = $numberOfResultsPerPage;
-
+    
     if ($numberOfResults === 'all') {
       // 10,000 search results is the default maximum amount of Elastic Search results.
       $requestedNumberOfResults = 10000;
     }
-
-    elseif ($numberOfResults === '25' || $numberOfResults === '50' || $numberOfResults === '100') {
-      $requestedNumberOfResults = intval($numberOfResults);
+    
+    elseif ($num = intval($numberOfResults)) {
+      $requestedNumberOfResults = $num;
     }
+
+    $arguments['size'] = $requestedNumberOfResults;
   }
 
   // Convert all 'q' arguments to a string joined by ' AND ' operator.
@@ -305,7 +416,7 @@ function build_request_data($beanObject) {
 
   // Form the final request url.
   $elasticSearchRequest = url($fisPubsEndpoint, ['query' => $arguments]);
-  return ['reqUrl' => $elasticSearchRequest, 'requestedNumberOfResults' => $requestedNumberOfResults, 'messages' => $messages];
+  return ['reqUrl' => $elasticSearchRequest, 'requestedNumberOfResults' => $requestedNumberOfResults, 'numberOfResultsPerPage' => $numberOfResultsPerPage, 'messages' => $messages];
 }
 
 function get_array_from_field_data($fieldArray, $fieldArrayFinalIdentifier) {

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -43,8 +43,9 @@ function cu_faculty_publications_bundle_menu() {
 }
 
 function person_publications_list_all_page($person_nid) {
-  $order = variable_get('all_publications_list_order', 'date-desc');
-  if ($person = node_load($person_nid) && $person->type == 'person') {
+  $person = node_load($person_nid);
+  if ($person && $person->type == 'person') {
+    $order = variable_get('all_publications_list_order', 'date-desc');
     $fakeBeanObject = new stdClass();
     $fakeBeanObject->field_faculty_publication_email = $person->field_person_email;
     $fakeBeanObject->field_faculty_publications_sort = [LANGUAGE_NONE => [0 => ['value' => $order]]];
@@ -477,7 +478,7 @@ function build_request_data($beanObject) {
       $requestedNumberOfResults = $num;
     }
 
-    $arguments['size'] = $numberOfResultsPerPage;
+    $arguments['size'] = $requestedNumberOfResults < $numberOfResultsPerPage ? $requestedNumberOfResults : $numberOfResultsPerPage;
   }
 
   // Convert all 'q' arguments to a string joined by ' AND ' operator.

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -33,13 +33,29 @@ function cu_faculty_publications_bundle_theme_registry_alter(&$theme_registry) {
 function cu_faculty_publications_bundle_menu() {
   $items = array();
   $items['faculty-publications/%'] = array(
-    'title' => 'All Publications',
+    'title callback' => 'person_publications_list_all_title',
+    'title arguments' => array(1),
     'description' => 'List of all of a particular faculty member\'s publications',
     'page callback' => 'person_publications_list_all_page',
     'page arguments' => array(1),
     'access callback' => TRUE
   );
   return $items;
+}
+
+/**
+ * Creates view for complete listing of a faculty member's publications at the url 'faculty-publications/[$person node id number].
+ */
+function person_publications_list_all_title($person_nid) {
+  $person = node_load($person_nid);
+
+  if ($person && $person->type == 'person') {
+
+    return t("Publications by {$person->title}");
+  }
+  else {
+    return 'Faculty Publications';
+  }
 }
 
 /**
@@ -59,7 +75,9 @@ function person_publications_list_all_page($person_nid) {
     return [
       'name' => [
         '#type' => 'markup',
-        '#markup' => l("<h3>{$person->title}</h3>", "node/{$person->nid}", ['html' => TRUE])
+        '#markup' => l("return to {$person->title}'s page", "node/{$person->nid}", ['attributes' => ['class' => ['breadcrumb']]]),
+        '#prefix' => '<p>',
+        '#suffix' => '</p>'
       ],
       'content' => publish_data($publicationData)
     ];
@@ -133,7 +151,7 @@ function cu_faculty_publications_bundle_block_view($delta = '') {
 
             $block['content']['full_list_link'] = array(
               '#type' => 'markup',
-              '#markup' => l("See a full list of {$node->title}'s publications", $link_url),
+              '#markup' => l("See a full list of {$node->title}'s publications", $link_url, ['attributes' => ['class' => ['breadcrumb']]]),
               '#prefix' => '<div>',
               '#suffix' => '</div>'
             );


### PR DESCRIPTION
1. Can be configured by visiting /admin/structure/block/manage/cu_faculty_publications_bundle/person_publications_list/configure
2. Can be inserted via Context (see issue comments #643)
3. grabs email from node of the person page it is loaded on. No other configuration/filter setup necessary
4. For logged-in users output should be basically the same as other blocks created with the cu_faculty_publications_bundle, with the following exceptions:
    - there are only a Person's 5 most recent publications listed as a default (can be changed by step 1. above)
    - the results are only related to the email found on a Person page.
5. For non-logged-in users, if a Person has no publications the block is simply not rendered