### PR TITLE
Avoiding collisions between warnings and person image

### DIFF
--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -129,7 +129,7 @@ function get_publication_data($cid, $skipCache, $beanObject) {
     // If the request failed still load from the cache but with a warning.
     else {
       $publicationData = $cache->data;
-      $publicationData['messages']['publications'] = "<div class=\"messages warning\">{$response->code}: There was a problem refreshing publication data. The results shown may not be the most up to date. Please check again later.</div>";
+      $publicationData['messages']['publications'] = "<div style=\"float:left\" class=\"messages warning\">{$response->code}: There was a problem refreshing publication data. The results shown may not be the most up to date. Please check again later.</div>";
       $publicationData['isFromCache'] = TRUE;
       return $publicationData;
     }
@@ -144,7 +144,7 @@ function get_publication_data($cid, $skipCache, $beanObject) {
         'total' => NULL,
         'results' => NULL,
         'requestedNumberOfResults' => NULL,
-        'error' => "<div class=\"messages error\">{$reqData['error']}: There was a problem connecting to the experts 'people' database.</div>"
+        'error' => "<div style=\"float:left\" class=\"messages error\">{$reqData['error']}: There was a problem connecting to the experts 'people' database.</div>"
       ];
     }
 
@@ -153,7 +153,7 @@ function get_publication_data($cid, $skipCache, $beanObject) {
         'total' => NULL,
         'results' => NULL,
         'requestedNumberOfResults' => NULL,
-        'error' => "<div class=\"messages warning\">{$reqData['warning']}</div>"
+        'error' => "<div style=\"float:left\" class=\"messages warning\">{$reqData['warning']}</div>"
       ];
     }
 
@@ -183,7 +183,7 @@ function get_publication_data($cid, $skipCache, $beanObject) {
           'requestedNumberOfResults' => $cache->data['requestedNumberOfResults'],
           'expiration' => $newExpiration,
           'reqUrl' => $cache->data['reqUrl'],
-          'error' => "<div class=\"messages error\">{$response->code}: There was a problem fetching publication data. Please check again later.</div>"
+          'error' => "<div style=\"float:left\" class=\"messages error\">{$response->code}: There was a problem fetching publication data. Please check again later.</div>"
         ];
         return $publicationData;
       }

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -348,7 +348,7 @@ function get_author_orcids($authorEmailArray, $dbUrl) {
   }
 
   if ($noResults) {
-    return ['warning' => "There was no publication data found for the selected author(s)"];
+    return ['warning' => "There was no publication data found for the selected author(s)."];
   }
 
   else {

--- a/modules/custom/cu_faculty_publications_bundle/templates/faculty-publication.tpl.php
+++ b/modules/custom/cu_faculty_publications_bundle/templates/faculty-publication.tpl.php
@@ -1,4 +1,4 @@
-<div class="padding-bottom margin-bottom border-bottom">
+<div class="padding-bottom margin-bottom">
   <h3 class="h5">
     <?php
       if ($doi) {

--- a/modules/features/people_content_type/css/people_content_type.css
+++ b/modules/features/people_content_type/css/people_content_type.css
@@ -27,6 +27,8 @@ img.image-medium, img.image-small { width: 100%; height: auto; }
 .person-container { overflow: hidden; }
 
 .person-photo { float: right; margin: 0 0 20px 20px; max-width: 320px; height: auto; }
+@media screen and (max-width: 960px) and (min-width: 420px) { .person-photo { max-width: 180px; } }
+@media screen and (max-width: 419px) { .person-photo { max-width: 120px; float: none; margin: 0 0 20px; } }
 
 /** Responsive tables. */
 @media screen and (max-width: 960px) { /* 450px */

--- a/modules/features/people_content_type/css/people_content_type.css
+++ b/modules/features/people_content_type/css/people_content_type.css
@@ -22,9 +22,10 @@ ul.cu-person-directory img { float: left; margin: 0 20px 20px 0; }
 span.responsive-label { display: none; }
 
 /* NODE VIEW */
-.person-photo img.image-medium, .person-photo img.image-small { float: right; margin: 0 0 20px 20px; max-width: 320px; height: auto; }
-@media screen and (max-width: 960px) and (min-width: 420px) { .person-photo img.image-medium, .person-photo img.image-small { max-width: 180px; } }
-@media screen and (max-width: 419px) { .person-photo img.image-medium, .person-photo img.image-small { max-width: 120px; float: none; margin: 0 0 20px; } }
+.person-container { flex-direction: row-reverse; }
+@media screen and (max-width: 786px) { .person-container { flex-direction: column; } }
+
+.person-photo img.image-medium, .person-photo img.image-small { width: 100%; height: auto; }
 
 /** Responsive tables. */
 @media screen and (max-width: 960px) { /* 450px */

--- a/modules/features/people_content_type/css/people_content_type.css
+++ b/modules/features/people_content_type/css/people_content_type.css
@@ -22,10 +22,11 @@ ul.cu-person-directory img { float: left; margin: 0 20px 20px 0; }
 span.responsive-label { display: none; }
 
 /* NODE VIEW */
-.person-container { flex-direction: row-reverse; }
-@media screen and (max-width: 786px) { .person-container { flex-direction: column; } }
+img.image-medium, img.image-small { width: 100%; height: auto; }
 
-.person-photo img.image-medium, .person-photo img.image-small { width: 100%; height: auto; }
+.person-container { overflow: hidden; }
+
+.person-photo { float: right; margin: 0 0 20px 20px; max-width: 320px; height: auto; }
 
 /** Responsive tables. */
 @media screen and (max-width: 960px) { /* 450px */

--- a/modules/features/people_content_type/css/people_content_type.css
+++ b/modules/features/people_content_type/css/people_content_type.css
@@ -24,8 +24,6 @@ span.responsive-label { display: none; }
 /* NODE VIEW */
 img.image-medium, img.image-small { width: 100%; height: auto; }
 
-.person-container { overflow: hidden; }
-
 .person-photo { float: right; margin: 0 0 20px 20px; max-width: 320px; height: auto; }
 @media screen and (max-width: 960px) and (min-width: 420px) { .person-photo { max-width: 180px; } }
 @media screen and (max-width: 419px) { .person-photo { max-width: 120px; float: none; margin: 0 0 20px; } }

--- a/modules/features/people_content_type/scss/people_content_type.scss
+++ b/modules/features/people_content_type/scss/people_content_type.scss
@@ -88,6 +88,15 @@ img.image-medium, img.image-small {
   margin: 0 0 20px 20px;
   max-width:320px;
   height: auto;
+
+  @media screen and (max-width:960px) and (min-width:420px) {
+    max-width:180px;
+  }
+  @media screen and (max-width:419px) {
+    max-width:120px;
+    float:none;
+    margin: 0 0 20px;
+  }
 }
 
 

--- a/modules/features/people_content_type/scss/people_content_type.scss
+++ b/modules/features/people_content_type/scss/people_content_type.scss
@@ -74,18 +74,19 @@ span.responsive-label {
 }
 
 /* NODE VIEW */
-
-.person-container {
-  flex-direction: row-reverse;
-
-  @media screen and (max-width: 786px) {
-    flex-direction: column;
-  }
+img.image-medium, img.image-small {
+  width: 100%;
+  height: auto;
 }
 
-.person-photo img.image-medium,
-.person-photo img.image-small {
-  width: 100%;
+.person-container {
+  overflow: hidden;
+}
+
+.person-photo {
+  float: right;
+  margin: 0 0 20px 20px;
+  max-width:320px;
   height: auto;
 }
 

--- a/modules/features/people_content_type/scss/people_content_type.scss
+++ b/modules/features/people_content_type/scss/people_content_type.scss
@@ -75,22 +75,20 @@ span.responsive-label {
 
 /* NODE VIEW */
 
-.person-photo img.image-medium,
-.person-photo img.image-small {
-  float: right;
-  margin: 0 0 20px 20px;
-  max-width:320px;
-  height: auto;
+.person-container {
+  flex-direction: row-reverse;
 
-  @media screen and (max-width:960px) and (min-width:420px) {
-    max-width:180px;
-  }
-  @media screen and (max-width:419px) {
-    max-width:120px;
-    float:none;
-    margin: 0 0 20px;
+  @media screen and (max-width: 786px) {
+    flex-direction: column;
   }
 }
+
+.person-photo img.image-medium,
+.person-photo img.image-small {
+  width: 100%;
+  height: auto;
+}
+
 
 /**
  * Responsive tables.

--- a/modules/features/people_content_type/scss/people_content_type.scss
+++ b/modules/features/people_content_type/scss/people_content_type.scss
@@ -79,10 +79,6 @@ img.image-medium, img.image-small {
   height: auto;
 }
 
-.person-container {
-  overflow: hidden;
-}
-
 .person-photo {
   float: right;
   margin: 0 0 20px 20px;

--- a/modules/features/people_content_type/templates/node--person.tpl.php
+++ b/modules/features/people_content_type/templates/node--person.tpl.php
@@ -1,53 +1,57 @@
 <?php hide($content['links']); ?>
-<div class="person-photo"><?php print render($content['field_person_photo']); ?></div>
+<div class="row person-container">
+  <div class="person-photo col-sm-4 col-xs-6"><?php print render($content['field_person_photo']); ?></div>
 
-<?php
-  // Add check for $person_title due to warning notice.
-  if (!isset($person_title)) {
-    $person_title = array();
-  }
-  if (!empty($content['field_person_title'])) {
-    $person_title[] = render($content['field_person_title']);
-  }
-  if (!empty($content['field_person_department']['#items'])) {
-    $person_title[] = render($content['field_person_department']);
-  }
-  $title = join(' &bull; ' , $person_title);
-  //print $title;
-?>
-<div class="person-job-titles"><?php print $content['job_titles']; ?></div>
-<div class="person-departments"><?php print $content['departments']; ?></div>
-<?php if(!empty($content['field_person_email']) || !empty($content['field_person_phone'])): ?>
-<div class="people-contact people-section">
-  <?php if(!empty($content['field_person_email'])): ?>
-    <div class="person-email person-contact-info-item"><i class="fa fa-envelope fa-fw"></i> <?php print render($content['field_person_email']); ?></div>
-  <?php endif; ?>
-  <?php if(!empty($content['field_person_phone'])): ?>
-    <div class="person-phone person-contact-info-item"><i class="fa fa-phone fa-fw"></i> <?php print render($content['field_person_phone']); ?></div>
-  <?php endif; ?>
-</div>
-<?php endif; ?>
-
-<?php if(!empty($content['field_person_website'])): ?>
-<div class="people-links people-section">
-  <?php print render($content['field_person_website']); ?>
-</div>
-<?php endif; ?>
-
-<?php if(!empty($content['field_person_address']) || !empty($content['field_person_office_hours'])): ?>
-<div class="people-office people-section">
-  <?php if(!empty($content['field_person_address'])): ?>
-    <?php print render($content['field_person_address']); ?>
-  <?php endif; ?>
-  <?php if(!empty($content['field_person_office_hours'])): ?>
-    <?php print render($content['field_person_office_hours']); ?>
-  <?php endif; ?>
-</div>
-<?php endif; ?>
-
-
-<?php if(!empty($content['body'])): ?>
-  <div class="people-bio">
-    <?php print render($content['body']); ?>
+  <?php
+    // Add check for $person_title due to warning notice.
+    if (!isset($person_title)) {
+      $person_title = array();
+    }
+    if (!empty($content['field_person_title'])) {
+      $person_title[] = render($content['field_person_title']);
+    }
+    if (!empty($content['field_person_department']['#items'])) {
+      $person_title[] = render($content['field_person_department']);
+    }
+    $title = join(' &bull; ' , $person_title);
+    //print $title;
+  ?>
+  <div class="person-info col-sm-8">
+    <div class="person-job-titles"><?php print $content['job_titles']; ?></div>
+    <div class="person-departments"><?php print $content['departments']; ?></div>
+    <?php if(!empty($content['field_person_email']) || !empty($content['field_person_phone'])): ?>
+    <div class="people-contact people-section">
+      <?php if(!empty($content['field_person_email'])): ?>
+        <div class="person-email person-contact-info-item"><i class="fa fa-envelope fa-fw"></i> <?php print render($content['field_person_email']); ?></div>
+      <?php endif; ?>
+      <?php if(!empty($content['field_person_phone'])): ?>
+        <div class="person-phone person-contact-info-item"><i class="fa fa-phone fa-fw"></i> <?php print render($content['field_person_phone']); ?></div>
+      <?php endif; ?>
+    </div>
+    <?php endif; ?>
+    
+    <?php if(!empty($content['field_person_website'])): ?>
+    <div class="people-links people-section">
+      <?php print render($content['field_person_website']); ?>
+    </div>
+    <?php endif; ?>
+    
+    <?php if(!empty($content['field_person_address']) || !empty($content['field_person_office_hours'])): ?>
+    <div class="people-office people-section">
+      <?php if(!empty($content['field_person_address'])): ?>
+        <?php print render($content['field_person_address']); ?>
+      <?php endif; ?>
+      <?php if(!empty($content['field_person_office_hours'])): ?>
+        <?php print render($content['field_person_office_hours']); ?>
+      <?php endif; ?>
+    </div>
+    <?php endif; ?>
+    
+    
+    <?php if(!empty($content['body'])): ?>
+      <div class="people-bio">
+        <?php print render($content['body']); ?>
+      </div>
+    <?php endif; ?>
   </div>
-<?php endif; ?>
+</div> <!-- row end -->

--- a/modules/features/people_content_type/templates/node--person.tpl.php
+++ b/modules/features/people_content_type/templates/node--person.tpl.php
@@ -1,6 +1,6 @@
 <?php hide($content['links']); ?>
-<div class="row person-container">
-  <div class="person-photo col-sm-4 col-xs-6"><?php print render($content['field_person_photo']); ?></div>
+<div class="person-container">
+  <div class="person-photo"><?php print render($content['field_person_photo']); ?></div>
 
   <?php
     // Add check for $person_title due to warning notice.
@@ -16,42 +16,40 @@
     $title = join(' &bull; ' , $person_title);
     //print $title;
   ?>
-  <div class="person-info col-sm-8">
-    <div class="person-job-titles"><?php print $content['job_titles']; ?></div>
-    <div class="person-departments"><?php print $content['departments']; ?></div>
-    <?php if(!empty($content['field_person_email']) || !empty($content['field_person_phone'])): ?>
-    <div class="people-contact people-section">
-      <?php if(!empty($content['field_person_email'])): ?>
-        <div class="person-email person-contact-info-item"><i class="fa fa-envelope fa-fw"></i> <?php print render($content['field_person_email']); ?></div>
-      <?php endif; ?>
-      <?php if(!empty($content['field_person_phone'])): ?>
-        <div class="person-phone person-contact-info-item"><i class="fa fa-phone fa-fw"></i> <?php print render($content['field_person_phone']); ?></div>
-      <?php endif; ?>
-    </div>
+  <div class="person-job-titles"><?php print $content['job_titles']; ?></div>
+  <div class="person-departments"><?php print $content['departments']; ?></div>
+  <?php if(!empty($content['field_person_email']) || !empty($content['field_person_phone'])): ?>
+  <div class="people-contact people-section">
+    <?php if(!empty($content['field_person_email'])): ?>
+      <div class="person-email person-contact-info-item"><i class="fa fa-envelope fa-fw"></i> <?php print render($content['field_person_email']); ?></div>
     <?php endif; ?>
-    
-    <?php if(!empty($content['field_person_website'])): ?>
-    <div class="people-links people-section">
-      <?php print render($content['field_person_website']); ?>
-    </div>
-    <?php endif; ?>
-    
-    <?php if(!empty($content['field_person_address']) || !empty($content['field_person_office_hours'])): ?>
-    <div class="people-office people-section">
-      <?php if(!empty($content['field_person_address'])): ?>
-        <?php print render($content['field_person_address']); ?>
-      <?php endif; ?>
-      <?php if(!empty($content['field_person_office_hours'])): ?>
-        <?php print render($content['field_person_office_hours']); ?>
-      <?php endif; ?>
-    </div>
-    <?php endif; ?>
-    
-    
-    <?php if(!empty($content['body'])): ?>
-      <div class="people-bio">
-        <?php print render($content['body']); ?>
-      </div>
+    <?php if(!empty($content['field_person_phone'])): ?>
+      <div class="person-phone person-contact-info-item"><i class="fa fa-phone fa-fw"></i> <?php print render($content['field_person_phone']); ?></div>
     <?php endif; ?>
   </div>
-</div> <!-- row end -->
+  <?php endif; ?>
+
+  <?php if(!empty($content['field_person_website'])): ?>
+  <div class="people-links people-section">
+    <?php print render($content['field_person_website']); ?>
+  </div>
+  <?php endif; ?>
+
+  <?php if(!empty($content['field_person_address']) || !empty($content['field_person_office_hours'])): ?>
+  <div class="people-office people-section">
+    <?php if(!empty($content['field_person_address'])): ?>
+      <?php print render($content['field_person_address']); ?>
+    <?php endif; ?>
+    <?php if(!empty($content['field_person_office_hours'])): ?>
+      <?php print render($content['field_person_office_hours']); ?>
+    <?php endif; ?>
+  </div>
+  <?php endif; ?>
+
+
+  <?php if(!empty($content['body'])): ?>
+    <div class="people-bio">
+      <?php print render($content['body']); ?>
+    </div>
+  <?php endif; ?>
+</div>

--- a/modules/features/people_content_type/templates/node--person.tpl.php
+++ b/modules/features/people_content_type/templates/node--person.tpl.php
@@ -1,5 +1,4 @@
 <?php hide($content['links']); ?>
-<div class="person-container">
   <div class="person-photo"><?php print render($content['field_person_photo']); ?></div>
 
   <?php
@@ -52,4 +51,3 @@
       <?php print render($content['body']); ?>
     </div>
   <?php endif; ?>
-</div>


### PR DESCRIPTION
The warning messages should no longer collide. On screens larger than 786px the person photo should be on the right side of the screen, as it was before. On Screens smaller than 786px the person photo should appear in its own line above all the other person info.

## Summary of work in this PR:
- removed float property from person image
- slightly reorganized node--person.tpl.php template
    1. wrapped almost everything in a div.row.person-container
    1. put person image (img tag) into its own div.person-photo with bootstrap column widths for responsiveness
    1. put all other person info into another div.person-info with bootstrap column widths for responsiveness
- changes to people_content_type.scss
    1. .person-container class on screens wider than 786px (bootstrap's sm size and larger) has `flex-direction: row-reverse;` (to take advantage of bootstrap's .row class being set to `display:flex;`) to keep person image on right side of screen.
    1. .person-container class on screens narrower than 786px (bootstrap's xs screen size) `flex-direction: column;` (to take advantage of bootstrap's .row class being set to `display:flex;`) to display everything as column with person image on top.
    1. removed previous media queries relating to the `.person-photo img.image-*` and replaced with simple styling of `width: 100%; height: auto;` so that this image's width is now set by its parent div.person-photo via the bootstrap column widths.