### PR TITLE
Enforce title field length on article node type. Resolves #679

### DIFF
--- a/modules/custom/express_layout/express_layout.admin.inc
+++ b/modules/custom/express_layout/express_layout.admin.inc
@@ -93,7 +93,9 @@ function express_layout_form_submit($form, &$form_state) {
   if ($express_layout == FALSE) {
     $node = node_load(arg(1));
     $layout_title = 'Layout: ' . $node->title;
-    if (strlen($layout_title) > 255) { $layout_title = substr($layout_title,0,255); }
+    if (strlen($layout_title) > 255) {
+      $layout_title = substr($layout_title, 0, 255);
+    }
     $values = array(
       'layout_id' => $node->nid,
       'title' => $layout_title,

--- a/modules/custom/express_layout/express_layout.admin.inc
+++ b/modules/custom/express_layout/express_layout.admin.inc
@@ -92,9 +92,11 @@ function express_layout_form_submit($form, &$form_state) {
   // Make a new layout entity if node doesn't have one already.
   if ($express_layout == FALSE) {
     $node = node_load(arg(1));
+    $layout_title = 'Layout: ' . $node->title;
+    if (strlen($layout_title) > 255) { $layout_title = substr($layout_title,0,255); }
     $values = array(
       'layout_id' => $node->nid,
-      'title' => 'Layout: ' . $node->title,
+      'title' => $layout_title,
       'node_type' => $node->type,
     );
 

--- a/modules/custom/express_layout/express_layout.module
+++ b/modules/custom/express_layout/express_layout.module
@@ -180,7 +180,9 @@ function express_layout_node_insert($node) {
   }
   $nid = $node->nid;
   $layout_title = 'Layout: ' . $node->title;
-  if (strlen($layout_title) > 255) { $layout_title = substr($layout_title,0,255); }
+  if (strlen($layout_title) > 255) {
+    $layout_title = substr($layout_title, 0, 255);
+  }
 
   $values = array(
     'layout_id' => $nid,
@@ -202,7 +204,9 @@ function express_layout_node_update($node) {
   }
   $nid = $node->nid;
   $layout_title = 'Layout: ' . $node->title;
-  if (strlen($layout_title) > 255) { $layout_title = substr($layout_title,0,255); }
+  if (strlen($layout_title) > 255) {
+    $layout_title = substr($layout_title, 0, 255);
+  }
 
   if ($layout = entity_load_single('express_layout', $nid)) {
     $layout->title = $layout_title;

--- a/modules/custom/express_layout/express_layout.module
+++ b/modules/custom/express_layout/express_layout.module
@@ -179,9 +179,12 @@ function express_layout_node_insert($node) {
     return;
   }
   $nid = $node->nid;
+  $layout_title = 'Layout: ' . $node->title;
+  if (strlen($layout_title) > 255) { $layout_title = substr($layout_title,0,255); }
+
   $values = array(
     'layout_id' => $nid,
-    'title' => 'Layout: ' . $node->title,
+    'title' => $layout_title,
     'node_type' => $node->type,
   );
   $layout = entity_create('express_layout', $values);
@@ -198,13 +201,16 @@ function express_layout_node_update($node) {
     return;
   }
   $nid = $node->nid;
+  $layout_title = 'Layout: ' . $node->title;
+  if (strlen($layout_title) > 255) { $layout_title = substr($layout_title,0,255); }
+
   if ($layout = entity_load_single('express_layout', $nid)) {
-    $layout->title = 'Layout: ' . $node->title;
+    $layout->title = $layout_title;
     entity_save('express_layout', $layout);
   } else {
     $values = array(
       'layout_id' => $nid,
-      'title' => 'Layout: ' . $node->title,
+      'title' => $layout_title,
       'node_type' => $node->type,
     );
     $layout = entity_create('express_layout', $values);


### PR DESCRIPTION
closes #679 

The problem occurs in express_layout, which uses the node title as the layout title but doesn't check string length. System fails when writing super-long titles to db. 

Problem solved by adding a check for string length and truncating those that are too long. 


