### PR TITLE
fix: added  method to cu_core. Resolves #790

### DIFF
--- a/modules/custom/cu_core/cu_core.module
+++ b/modules/custom/cu_core/cu_core.module
@@ -8,9 +8,29 @@
  * Implements hook_menu_alter().
  */
 function cu_core_menu_alter(&$items) {
-  // This is a place to remove visibility for enpoints
-  // unnecessarily set as public.
-  $items['filter/tips']['access callback'] = FALSE;
+  // Remove visibility for enpoints unnecessarily set as public.
+  // Add endpoints to the array in the foreach loop.
+  foreach (['filter/tips'] as $endpoint) {
+    if ($items[$endpoint]) {
+      $items[$endpoint]['access callback'] = '_check_authenticated_user_role';
+      unset($items[$endpoint]['access arguments']);
+    }
+  }
+}
+
+/**
+ * Checks a user's role passed in from cu_core_menu_alter().
+ */
+function _check_authenticated_user_role() {
+  global $user;
+
+  foreach ($user->roles as $index => $role) {
+    if ($role == 'authenticated user') {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
 }
 
 /**

--- a/modules/custom/cu_core/cu_core.module
+++ b/modules/custom/cu_core/cu_core.module
@@ -6,6 +6,15 @@
 
 /**
  * Implements hook_module_implements_alter().
+ */
+function cu_sitemap_menu_alter(&$items) {
+  // This is a place to remove visibility for enpoints
+  // unnecessarily set as public.
+  $items['filter/tips']['access callback'] = FALSE;
+}
+
+/**
+ * Implements hook_module_implements_alter().
  *
  * @param array $implementations
  *   List of modules that implement hook.

--- a/modules/custom/cu_core/cu_core.module
+++ b/modules/custom/cu_core/cu_core.module
@@ -5,9 +5,9 @@
  */
 
 /**
- * Implements hook_module_implements_alter().
+ * Implements hook_menu_alter().
  */
-function cu_sitemap_menu_alter(&$items) {
+function cu_core_menu_alter(&$items) {
   // This is a place to remove visibility for enpoints
   // unnecessarily set as public.
   $items['filter/tips']['access callback'] = FALSE;

--- a/modules/custom/cu_core/cu_core.module
+++ b/modules/custom/cu_core/cu_core.module
@@ -24,7 +24,7 @@ function cu_core_menu_alter(&$items) {
 function _check_authenticated_user_role() {
   global $user;
 
-  foreach ($user->roles as $index => $role) {
+  foreach ($user->roles as $role) {
     if ($role == 'authenticated user') {
       return TRUE;
     }


### PR DESCRIPTION
I added the method `cu_core_menu_alter()` as a way to suppress the visibility of the `/filter/tips` endpoint. We could add any other such endpoints here as well.