### PR TITLE
Changes to express_site_metrics module

### DIFF
--- a/modules/custom/atlas/atlas_statistics/atlas_statistics.module
+++ b/modules/custom/atlas/atlas_statistics/atlas_statistics.module
@@ -63,7 +63,7 @@ function atlas_statistics() {
     '#markup' => '<div><strong>Statistics Item URL</strong>: ' . $statistics_url_markup . '</div>',
   );
 
-  module_load_include('inc', 'atlas_statistics');
+  // module_load_include('inc', 'atlas_statistics');
   $atlas_statistics = atlas_statistics_get_statistics();
 
   $form['atlas_statistics'] = array(
@@ -108,7 +108,7 @@ function atlas_statistics() {
  */
 function atlas_statistics_submit($form, &$form_state) {
 
-  module_load_include('inc', 'atlas_statistics');
+  // module_load_include('inc', 'atlas_statistics');
   $request_data = atlas_statistics_get_statistics();
 
   // Set the etag from the form.
@@ -204,3 +204,215 @@ function atlas_statistics_pretty_print($json) {
   return $result;
 }
 
+/**
+ * Get all statistics defined by the API.
+ */
+function atlas_statistics_get_statistics() {
+  // TODO: Support overriding statisitcs. array_unique won't work here because
+  // we need to compare the keys not the values.
+  $statistics = array_merge(module_invoke_all('atlas_statistics'));
+  return $statistics;
+}
+
+/**
+ * Implements hook_atlas_statistics().
+ */
+function atlas_statistics_atlas_statistics() {
+  $statistics_data = array();
+
+  $statistics_data['name'] = variable_get('site_name', NULL);
+  $statistics_data['status'] = variable_get('atlas_status', NULL);
+  $statistics_data['site'] = variable_get('atlas_id', NULL);
+
+  // Count Nodes.
+  $node_query = db_select('node', 'n');
+  $node_query->addExpression('COUNT(type)', 'count_type');
+  $node_query->addExpression('MAX(changed)', 'max_changed');
+  $node_query->orderBy('max_changed', 'DESC');
+  $node_result = $node_query->execute();
+  $all_nodes = $node_result->fetchAll();
+
+  // Count by type.
+  $node_type_counts = array();
+  foreach ($all_nodes as $object) {
+    $node_type_counts[] = $object->count_type;
+  }
+  // Total up the number of nodes.
+  $number_nodes = array_sum($node_type_counts);
+  if (empty($number_nodes)) {
+    $number_nodes = 0;
+  }
+  $statistics_data['nodes_total'] = $number_nodes;
+
+  // Days since last edit.
+  $most_recent_edit = $all_nodes[0]->max_changed;
+  $days_since_last_edit = ((time() - $most_recent_edit) / 86400);
+  $statistics_data['days_since_last_edit'] = floor($days_since_last_edit);
+
+  // List users.
+  $users = entity_load('user');
+  $user_roles = [
+    'access_manager',
+    'campaign_manager',
+    'configuration_manager',
+    'edit_my_content',
+    'form_manager',
+    'site_editor',
+    'site_owner',
+  ];
+  foreach ($users as $user_id => $user) {
+    // Make sure username and email exist before putting them in the array.
+    // Removes user 0 (aka Anonymous).
+    // Also test to see if the user is active, do not include blocked accounts.
+    if ($user->name && $user->mail && $user->status == 1) {
+      foreach ($user_roles as $role) {
+        if (in_array($role, $user->roles, FALSE)) {
+          $statistics_data['users']['username'][$role][] = $user->name;
+          $statistics_data['users']['email_address'][$role][] = $user->mail;
+          $statistics_data['users']['counts'][$role]++;
+        }
+      }
+    }
+  }
+
+  // Add report of overridden features if the module is enabled and there are
+  // overridden features.
+  $overridden = _atlas_statistics_get_features_statuses();
+  if (module_exists('features') && !empty($overridden)) {
+    $statistics_data['overridden_features'] = $overridden;
+  }
+
+  // Returns system status boolean and resolves to TRUE or FALSE.
+  module_load_include('inc', 'system', 'system.admin');
+  if (system_status(TRUE)) {
+    $statistics_data['drupal_system_status'] = TRUE;
+    watchdog(
+      'atlas_statistics',
+      'System Status is True | %requirements',
+      array(
+        '%requirements' => _atlas_drush_core_requirements()
+      ),
+      WATCHDOG_WARNING,
+      NULL
+    );
+  }
+  else {
+    $statistics_data['drupal_system_status'] = FALSE;
+  }
+
+
+
+  // Get role ids to search for in query.
+  $role_ids = [];
+  $user_roles = [
+    'access_manager',
+    'campaign_manager',
+    'configuration_manager',
+    'edit_my_content',
+    'form_manager',
+    'site_editor',
+    'site_owner',
+  ];
+  foreach ($user_roles as $val) {
+    $temp_role = user_role_load_by_name($val);
+    if (isset($temp_role->rid)) {
+      $role_ids[] = $temp_role->rid;
+    }
+  }
+
+  // Add last login of any user.
+  $last_login = db_query('SELECT MAX(login) FROM users INNER JOIN users_roles ON users.uid=users_roles.uid WHERE rid IN (:roles) AND login > 1', [':roles' => $role_ids])->fetchCol('login');
+  $statistics_data['days_since_last_login'] = is_array($last_login) && is_numeric($last_login[0]) ? floor((time() - $last_login[0]) / (60*60*24)) : '-1';
+
+  return $statistics_data;
+}
+
+/**
+ * Function that checks each feature and returns a list of overridden ones.
+ *
+ * @return array
+ *   List of overridden features and their statuses.
+ */
+function _atlas_statistics_get_features_statuses() {
+  module_load_include('inc', 'features', 'features.export');
+  $overridden_features = array();
+  $feature_statuses = array(
+    1 => 'Overridden',
+    2 => 'Needs Review',
+    3 => 'Rebuilding',
+    4 => 'Conflict',
+    5 => 'Disabled',
+    6 => 'Checking',
+  );
+  // Loop through each feature, check the status, and capture overridden ones.
+  $features = features_get_features();
+  foreach ($features as $feature) {
+    $feature_status = features_get_storage($feature->name);
+    if ($feature_status != 0) {
+      $overridden_features[$feature->name] = $feature_statuses[$feature_status];
+    }
+  }
+  return $overridden_features;
+}
+
+/**
+ * Determines if the webform is active based upon the date of last submission.
+ *
+ * @param int $nid
+ *   Webform node id.
+ * @param string $date
+ *   A human readable date. Defaults to '13 months ago'.
+ *
+ * @return bool
+ *   TRUE if last submission was within the provided date. FALSE otherwise.
+ */
+function atlas_statistics_webform_is_active($nid, $date = '13 months ago') {
+  $submissions = webform_get_submissions(array('nid' => $nid));
+  if (empty($submissions)) {
+    // If there are no submissions, then consider the webform inactive.
+    return FALSE;
+  }
+  else {
+    // Get last submission; check that it was submitted since the provided date.
+    $last_submission = end($submissions);
+    return $last_submission->submitted > strtotime($date);
+  }
+}
+
+/**
+ * Replicate functionality of https://github.com/drush-ops/drush/blob/8.x/commands/core/core.drush.inc#L797
+ */
+function _atlas_drush_core_requirements() {
+  $return_string = NULL;
+  include_once DRUPAL_ROOT . '/includes/install.inc';
+  $severities = array(
+    REQUIREMENT_INFO => t('Info'),
+    REQUIREMENT_OK => t('OK'),
+    REQUIREMENT_WARNING => t('Warning'),
+    REQUIREMENT_ERROR => t('Error'),
+  );
+  drupal_load_updates();
+  $requirements = module_invoke_all('requirements', 'runtime');
+  // If a module uses "$requirements[] = " instead of
+  // "$requirements['label'] = ", then build a label from
+  // the title.
+
+  foreach($requirements as $key => $info) {
+    if (is_numeric($key)) {
+      unset($requirements[$key]);
+      $new_key = strtolower(str_replace(' ', '_', $info['title']));
+      $requirements[$new_key] = $info;
+    }
+  }
+  ksort($requirements);
+  $min_severity = 2;
+  foreach($requirements as $key => $info) {
+    $severity = array_key_exists('severity', $info) ? $info['severity'] : -1;
+    $requirements[$key]['sid'] = $severity;
+    $requirements[$key]['severity'] = $severities[$severity];
+    if ($severity >= $min_severity) {
+      $return_string .= $requirements[$key]['title'] . ' - ' . $requirements[$key]['value'] . ' | ';
+    }
+  }
+  return $return_string;
+}

--- a/modules/custom/express_site_metrics/classes/express_site_metrics_inspector.php
+++ b/modules/custom/express_site_metrics/classes/express_site_metrics_inspector.php
@@ -29,7 +29,8 @@ class SiteMetricsInspector {
    *   Associative array of site metrics data.
    */
   private static function gatherData($drupalModuleInvokeAll, $hookNameForInvokeAll) {
-    $metricsData = array_merge($drupalModuleInvokeAll($hookNameForInvokeAll));
+    $dataAfterModuleInvokeAll = $drupalModuleInvokeAll($hookNameForInvokeAll);
+    $metricsData = array_merge($dataAfterModuleInvokeAll);
     return $metricsData;
   }
 

--- a/modules/custom/express_site_metrics/express_site_metrics.module
+++ b/modules/custom/express_site_metrics/express_site_metrics.module
@@ -64,6 +64,11 @@ function express_site_metrics_access() {
 function express_site_metrics_json() {
   drupal_add_http_header('Status', 200, TRUE);
   drupal_add_http_header('Content-Type', 'application/json');
+
+  // Right now (5/2021) this method uses code from atlas_statistics.module.
+  // That module already created a hook for gathering desired data and I just
+  // used it. If and when we decide to change data gathered for site metrics we
+  // can implement similar code in this module.
   $metrics = SiteMetricsInspector::makeReport('module_invoke_all', 'atlas_statistics');
   echo $metrics;
 }

--- a/modules/custom/express_site_metrics/express_site_metrics.module
+++ b/modules/custom/express_site_metrics/express_site_metrics.module
@@ -15,7 +15,7 @@ function express_site_metrics_menu() {
     'access arguments' => array('administer modules'),
   );
 
-  $items['admin/config/express/metrics/json'] = array(
+  $items['express/metrics/json'] = array(
     'title' => 'Express Site Metrics JSON endpoint',
     'access callback' => 'express_site_metrics_access',
     'page callback' => 'express_site_metrics_json',


### PR DESCRIPTION
#### This PR Includes
- changing endpoint that requires a token for json data so that it is now simply `/express/metrics/json` instead of `/admin/config/express/metrics/json`.
    - Being behind `/admin` forced the request to the user sign in page.
- including metrics data that was unintentionally left out previously.
- some comments etc.