### PR TITLE
Remove theme access from site_editor role

### DIFF
--- a/modules/custom/express_block_designer/express_block_designer.module
+++ b/modules/custom/express_block_designer/express_block_designer.module
@@ -187,7 +187,6 @@ function express_block_designer_secure_permissions($role) {
       'use block designer',
     ),
     'site_editor' => array(
-      'administer block designer themes',
       'use block designer',
     ),
     'site_owner' => array(

--- a/tests/behat/features/Express/design/blockdesigner.feature
+++ b/tests/behat/features/Express/design/blockdesigner.feature
@@ -37,7 +37,7 @@ Examples:
 | administrator    | "A name describing your block theme" |
 | site_owner       | "A name describing your block theme" |
 | edit_my_content  | "Access denied" |
-# | site_editor      | "Access denied" | CAN ADD AND USE BLOCK DESIGNER
+| site_editor      | "Access denied" |
 | edit_only        | "Access denied" |
 | access_manager   | "Access denied" |
 | configuration_manager | "A name describing your block theme" |


### PR DESCRIPTION
Remove permission 'administer block designer themes' from Site Editor role. Only Site Owners should have ability to create site designs. 

See https://github.com/CuBoulder/express_mono/issues/833

closes #833 