### PR TITLE
chg: changing logic to look for CLEAR token in title.

### DIFF
--- a/modules/contrib/rave_alerts/.gitignore
+++ b/modules/contrib/rave_alerts/.gitignore
@@ -1,0 +1,1 @@
+.gitconfig

--- a/modules/contrib/rave_alerts/rave_alerts.info
+++ b/modules/contrib/rave_alerts/rave_alerts.info
@@ -3,8 +3,8 @@ description = Checks RAVE for new alerts via RSS.  Provides block to display ale
 core = 7.x
 configure = admin/config/system/rave-alerts
 stylesheets[all][] = css/rave_alerts.css
-; Information added by Drupal.org packaging script on 2021-05-26
+; Information added by Drupal.org packaging script on 2021-07-14
 version = "7.x-1.x-dev"
 core = "7.x"
 project = "rave_alerts"
-datestamp = "1622048331"
+datestamp = "1626302264"

--- a/modules/contrib/rave_alerts/rave_alerts.install
+++ b/modules/contrib/rave_alerts/rave_alerts.install
@@ -11,6 +11,9 @@ function rave_alerts_install() {
   // set sane defaults
   variable_set('rave_alerts_rss_url', 'http://www.getrave.com/rss/cuboulder/channel1');
   variable_set('rave_alerts_deafult_read_more_url', 'http://alerts.colorado.edu');
+
+  // The variable 'rave_alerts_check_enable' is set to 1 in cu_core.install.
+  // As long as the cu_core module is installed it will default to 1.
   variable_set('rave_alerts_check_enable', 0);
   variable_set('rave_alerts_display', 0);
   variable_set('rave_alerts_network_fail_message', 'Network Failure: Please go directly to http://alerts.colorado.edu for more information.');

--- a/modules/contrib/rave_alerts/rave_alerts.module
+++ b/modules/contrib/rave_alerts/rave_alerts.module
@@ -103,7 +103,8 @@ function rave_alerts_remote_data() {
   if (variable_get('rave_alerts_check_enable', 0)) {
     $url = variable_get('rave_alerts_rss_url', 'https://www.getrave.com/rss/DemoUniversityAlert/channel8');
 
-    if ($cache = cache_get('rave_alert', 'cache_rave_alerts')) {
+    $cache = cache_get('rave_alert', 'cache_rave_alerts');
+    if ($cache && $cache->expire > time()) {
       $data = $cache->data;
     }
     else {
@@ -133,6 +134,9 @@ function rave_alerts_remote_data() {
           $isCLEAR = strpos($data['channel']['item']['title'], variable_get('rave_alerts_clear_text', '[CLEAR]'));
           $isACTIVE = strpos($data['channel']['item']['title'], variable_get('rave_alerts_active_text', '[ACTIVE]'));
 
+          // Two variables in the database are checked for expected functionality:
+            // 1. 'rave_alerts_display': checked to decide if alert is shown on page load.
+            // 2. 'rave_alerts_active_event': checked by rave_alerts.js to decide if alert continues to be shown.
           if ($isCLEAR !== FALSE) {
             variable_set('rave_alerts_active_event', 0);
             variable_set('rave_alerts_display', 0);

--- a/modules/contrib/rave_alerts/rave_alerts.module
+++ b/modules/contrib/rave_alerts/rave_alerts.module
@@ -137,35 +137,38 @@ function rave_alerts_remote_data() {
           // Two variables in the database are checked for expected functionality:
             // 1. 'rave_alerts_display': checked to decide if alert is shown on page load.
             // 2. 'rave_alerts_active_event': checked by rave_alerts.js to decide if alert continues to be shown.
+          // The PHP function strpos() can return int 0, which might be evalauted as falsey.
+          // We check for FALSE to avoid this.
           if ($isCLEAR !== FALSE) {
             variable_set('rave_alerts_active_event', 0);
             variable_set('rave_alerts_display', 0);
-            watchdog('rave_alerts', 'CLEAR token found. Clearing rave alert.');
+            // watchdog('rave_alerts', 'CLEAR token found. Clearing rave alert.');
           }
 
           if ($isACTIVE !== FALSE) {
             variable_set('rave_alerts_active_event', 1);
-            watchdog('rave_alerts', 'ACTIVE token found');
+            // watchdog('rave_alerts', 'ACTIVE token found');
           }
 
+          // This is an active event. We have an alert message that has not been cleared yet.
           if ($isCLEAR === FALSE) {
-            $logMessageData = [
-              'title' => $data['channel']['item']['title'],
-              'description' => $data['channel']['item']['description']
-            ];
             variable_set('rave_alerts_display', 1);
-            watchdog('rave_alerts', 'New Rave RSS item -> @title: @description', $logMessageData);
+            // $logMessageData = [
+            //   'title' => $data['channel']['item']['title'],
+            //   'description' => $data['channel']['item']['description']
+            // ];
+            // watchdog('rave_alerts', 'New Rave RSS item -> @title: @description', $logMessageData);
           }
         }
         // @TODO: Add option to leave all clear message up for X hours
       }
       // If response code != 200
       else {
-        variable_set('rave_alerts_active_event', 0);
-        variable_set('rave_alerts_display', 0);
-
         $logMessage = "Bad Request: {$response->code} - {$response->error}. Request URL: {$response->url}";
         watchdog('rave_alerts', $logMessage);
+
+        // Return the old cached alert data in this case.
+        $data = $cache->data;
       }
     }
   }

--- a/modules/contrib/rave_alerts/rave_alerts.module
+++ b/modules/contrib/rave_alerts/rave_alerts.module
@@ -140,7 +140,6 @@ function rave_alerts_remote_data() {
           }
 
           if ($isACTIVE !== FALSE) {
-            variable_set('rave_alerts_display', 1);
             variable_set('rave_alerts_active_event', 1);
             watchdog('rave_alerts', 'ACTIVE token found');
           }
@@ -151,7 +150,7 @@ function rave_alerts_remote_data() {
               'description' => $data['channel']['item']['description']
             ];
             variable_set('rave_alerts_display', 1);
-            watchdog('rave_alerts', 'New Rave RSS item -> @tile: @description', $logMessageData);
+            watchdog('rave_alerts', 'New Rave RSS item -> @title: @description', $logMessageData);
           }
         }
         // @TODO: Add option to leave all clear message up for X hours

--- a/modules/contrib/rave_alerts/rave_alerts.module
+++ b/modules/contrib/rave_alerts/rave_alerts.module
@@ -133,19 +133,19 @@ function rave_alerts_remote_data() {
           $isCLEAR = strpos($data['channel']['item']['title'], variable_get('rave_alerts_clear_text', '[CLEAR]'));
           $isACTIVE = strpos($data['channel']['item']['title'], variable_get('rave_alerts_active_text', '[ACTIVE]'));
 
-          if ($isCLEAR) {
+          if ($isCLEAR !== FALSE) {
             variable_set('rave_alerts_active_event', 0);
             variable_set('rave_alerts_display', 0);
             watchdog('rave_alerts', 'CLEAR token found. Clearing rave alert.');
           }
 
-          if ($isACTIVE) {
+          if ($isACTIVE !== FALSE) {
             variable_set('rave_alerts_display', 1);
             variable_set('rave_alerts_active_event', 1);
             watchdog('rave_alerts', 'ACTIVE token found');
           }
 
-          if ($isCLEAR == FALSE) {
+          if ($isCLEAR === FALSE) {
             $logMessageData = [
               'title' => $data['channel']['item']['title'],
               'description' => $data['channel']['item']['description']

--- a/modules/contrib/rave_alerts/rave_alerts.module
+++ b/modules/contrib/rave_alerts/rave_alerts.module
@@ -126,20 +126,32 @@ function rave_alerts_remote_data() {
           $data = json_decode($data, true);
           //@TODO: Make the cache timeout configurable
           cache_set('rave_alert', $data, 'cache_rave_alerts', time() + 60);
+
           // There is a new RSS item.  Evaluate the description for triggers.
-          // assume we are going to display this
-          variable_set('rave_alerts_display', 1);
           variable_set('rave_alerts_pubdate', $data['channel']['item']['pubDate']);
 
-          // Check for [Active] in rss title.
-          if (strpos($data['channel']['item']['title'], variable_get('rave_alerts_active_text', '[ACTIVE]'))) {
-             variable_set('rave_alerts_active_event', 1);
-             watchdog('rave_alerts', 'ACTIVE token found');
+          $isCLEAR = strpos($data['channel']['item']['title'], variable_get('rave_alerts_clear_text', '[CLEAR]'));
+          $isACTIVE = strpos($data['channel']['item']['title'], variable_get('rave_alerts_active_text', '[ACTIVE]'));
+
+          if ($isCLEAR) {
+            variable_set('rave_alerts_active_event', 0);
+            variable_set('rave_alerts_display', 0);
+            watchdog('rave_alerts', 'CLEAR token found. Clearing rave alert.');
           }
-          else {
-             variable_set('rave_alerts_active_event', 0);
-             variable_set('rave_alerts_display', 0);
-             watchdog('rave_alerts', 'ACTIVE token NOT found');
+
+          if ($isACTIVE) {
+            variable_set('rave_alerts_display', 1);
+            variable_set('rave_alerts_active_event', 1);
+            watchdog('rave_alerts', 'ACTIVE token found');
+          }
+
+          if ($isCLEAR == FALSE) {
+            $logMessageData = [
+              'title' => $data['channel']['item']['title'],
+              'description' => $data['channel']['item']['description']
+            ];
+            variable_set('rave_alerts_display', 1);
+            watchdog('rave_alerts', 'New Rave RSS item -> @tile: @description', $logMessageData);
           }
         }
         // @TODO: Add option to leave all clear message up for X hours


### PR DESCRIPTION
Now the data flow is: 
1. If CLEAR token: (show no alert)
    - set rave_alerts_active_event to 0.
    - set rave_alerts_display to 0.
    - log clear event.
2. If ACTIVE token: (still not showing anything)
    - set rave_alerts_active_event to 1.
    - log ACTIVE token is found.
3. If no CLEAR token is found: (show alert)
    - set rave_alerts_display to 1.
    - log new rave rss event.

This seems like a decent replacement of the original code (see comments in #842), preserving its focus on the CLEAR token instead of the ACTIVE token. In the original code an alert was shown unless there was a CLEAR token in the title. The ACTIVE token was also searched for but that was not the condition that triggered an alert's display.

With these changes a [CLEAR] token should turn alerts off and its absence will 'turn on' an alert and log it. If there is an [ACTIVE] token there is an additional log entry and the setting `rave_alerts_active_event = 1`.