### PR TITLE
Faculty Publications update

### DIFF
--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.js
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.js
@@ -1,0 +1,8 @@
+const allAuthors = document.querySelectorAll('.all-authors');
+
+allAuthors.forEach(detailsElement => {
+  detailsElement.addEventListener('toggle', event => {
+    console.log(event.target);
+    event.target.firstElementChild.firstElementChild.toggleAttribute('hidden');
+  });
+});

--- a/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
+++ b/modules/custom/cu_faculty_publications_bundle/cu_faculty_publications_bundle.module
@@ -359,7 +359,7 @@ function get_publication_data($cid, $skipCache, $beanObject) {
 }
 
 /**
- * This is where the request for elastic search is constructed.
+ * This is where the page output is created.
  *
  * @param array $publicationData
  *   Results from either the cache or requesting experts.colorado.edu as returned by get_publication_data().
@@ -394,6 +394,10 @@ function publish_data(array $publicationData) {
       }
 
       $output['publications'][]['#markup'] = theme('pager');
+      drupal_add_js(drupal_get_path(
+        'module', 'cu_faculty_publications_bundle') . '/cu_faculty_publications_bundle.js',
+        ['scope' => 'footer']
+      );
     }
 
     else {

--- a/modules/custom/cu_faculty_publications_bundle/templates/faculty-publication.tpl.php
+++ b/modules/custom/cu_faculty_publications_bundle/templates/faculty-publication.tpl.php
@@ -9,17 +9,50 @@
       }
     ?>
   </h3>
-  <strong>Authors:</strong>
-  <?php
-    $names = array();
-    foreach ($authors as $author) {
-      $names[] = l($author['name'], $author['uri']);
-    }
-    print implode($names, '; ');
-  ?><br />
+  <div id="cu-authors">
+    <strong>CU Boulder Authors:</strong>
+    <?php
+      $names = array();
+      foreach ($authors as $author) {
+        $names[] = l($author['name'], $author['uri']);
+      }
+      print implode('; ', $names);
+    ?>
+  </div>
+  <div style="display: flex">
+    <strong>All Authors: </strong>
+    <?php if (strlen($citedAuthors) < 100): ?>
+      <?php print $citedAuthors; ?>
+
+    <?php else: ?>
+      <?php $allAuthorArray = explode("; ", $citedAuthors); ?>
+      <details style="margin-left: 1rem" id="all-authors">
+        <summary>
+          <span id=all-authors-truncated><?php print substr($citedAuthors, 0, 100) . "..."; ?></span>
+        </summary>
+
+        <ul id="all-authors-list">
+
+          <?php foreach($allAuthorArray as $author): ?>
+            <li><?php print $author; ?></li>
+          <?php endforeach; ?>
+
+        </ul>
+      </details>
+    <?php endif; ?>
+  </div>
   <?php if (!empty($publishedIn)): ?>
     <strong>Published in:</strong> <?php print l($publishedIn['name'], $publishedIn['uri']); ?><br />
   <?php endif; ?>
   <strong>Publication Date:</strong> <?php print $publicationDate; ?><br />
   <strong>Type:</strong> <?php print $mostSpecificType; ?>
 </div>
+<!-- <script>
+  const allAuthors = document.querySelector('.all-authors');
+  const allAuthorsTruncated = document.querySelector('.all-authors-truncated')
+  const allAuthorsList = document.querySelector('.all-authors-list')
+  allAuthors.addEventListener("toggle", (event) => {
+    allAuthorsTruncated.toggleAttribute("hidden")
+    allAuthorsList.toggleAttribute("hidden")
+  })
+</script> -->

--- a/modules/custom/cu_faculty_publications_bundle/templates/faculty-publication.tpl.php
+++ b/modules/custom/cu_faculty_publications_bundle/templates/faculty-publication.tpl.php
@@ -1,4 +1,4 @@
-<div class="padding-bottom margin-bottom">
+<div class="faculty-publication padding-bottom margin-bottom">
   <h3 class="h5">
     <?php
       if ($doi) {
@@ -9,7 +9,7 @@
       }
     ?>
   </h3>
-  <div id="cu-authors">
+  <div class="cu-authors">
     <strong>CU Boulder Authors:</strong>
     <?php
       $names = array();
@@ -19,19 +19,19 @@
       print implode('; ', $names);
     ?>
   </div>
-  <div style="display: flex">
-    <strong>All Authors: </strong>
+  <div class="all-authors-container" style="display: flex">
+    <strong style="margin-right:.5rem; width: 85px;">All Authors:</strong>
     <?php if (strlen($citedAuthors) < 100): ?>
       <?php print $citedAuthors; ?>
 
     <?php else: ?>
       <?php $allAuthorArray = explode("; ", $citedAuthors); ?>
-      <details style="margin-left: 1rem" id="all-authors">
+      <details style="margin-left: .5rem" class="all-authors">
         <summary>
-          <span id=all-authors-truncated><?php print substr($citedAuthors, 0, 100) . "..."; ?></span>
+          <span class=all-authors-truncated><?php print substr($citedAuthors, 0, 120) . "..."; ?></span>
         </summary>
 
-        <ul id="all-authors-list">
+        <ul class="all-authors-list">
 
           <?php foreach($allAuthorArray as $author): ?>
             <li><?php print $author; ?></li>
@@ -47,12 +47,4 @@
   <strong>Publication Date:</strong> <?php print $publicationDate; ?><br />
   <strong>Type:</strong> <?php print $mostSpecificType; ?>
 </div>
-<!-- <script>
-  const allAuthors = document.querySelector('.all-authors');
-  const allAuthorsTruncated = document.querySelector('.all-authors-truncated')
-  const allAuthorsList = document.querySelector('.all-authors-list')
-  allAuthors.addEventListener("toggle", (event) => {
-    allAuthorsTruncated.toggleAttribute("hidden")
-    allAuthorsList.toggleAttribute("hidden")
-  })
-</script> -->
+


### PR DESCRIPTION
### Work in this pr:
- Added line to template for "CU Authors"
- Added line to template for "All Authors"
    - the full author list is found in each experts database record as "citedAuthors" and is a string
    - if all citedAuthors string is 100 characters or less show simply print the string
    - if it is longer than that show a truncated string with a toggle that shows a list of all authors
- Added some javascript code to help display the longer citedAuthors lists.